### PR TITLE
Beacon synth lock

### DIFF
--- a/oresat_configs/base/c3.yaml
+++ b/oresat_configs/base/c3.yaml
@@ -181,7 +181,7 @@ objects:
         access_type: ro
         unit: dB
 
-      - subindex: 0x3
+      - subindex: 0x4
         name: synth_lock
         data_type: bool
         description: lband si41xx synthesizer lock indicator

--- a/oresat_configs/base/c3.yaml
+++ b/oresat_configs/base/c3.yaml
@@ -181,6 +181,12 @@ objects:
         access_type: ro
         unit: dB
 
+      - subindex: 0x3
+        name: synth_lock
+        data_type: bool
+        description: lband si41xx synthesizer lock indicator
+        access_type: ro
+
   - index: 0x4007
     name: uhf
     object_type: record

--- a/oresat_configs/oresat0_5/beacon.yaml
+++ b/oresat_configs/oresat0_5/beacon.yaml
@@ -22,6 +22,7 @@ fields:
   - [lband, rx_bytes]
   - [lband, rx_packets]
   - [lband, rssi]
+  - [lband, synth_lock]
   - [uhf, rx_bytes]
   - [uhf, rx_packets]
   - [uhf, rssi]

--- a/tests/test_oresat0.py
+++ b/tests/test_oresat0.py
@@ -9,5 +9,5 @@ class TestOreSat0(TestConfig):
     """Test the OreSat0 OD database."""
 
     def setUp(self):
-        self.id = OreSatId.ORESAT0_5
+        self.id = OreSatId.ORESAT0
         self.config = OreSatConfig(self.id)

--- a/tests/test_oresat0_5.py
+++ b/tests/test_oresat0_5.py
@@ -9,5 +9,5 @@ class TestOreSat0_5(TestConfig):
     """Test the OreSat0.5 OD database"""
 
     def setUp(self):
-        self.id = OreSatId.ORESAT0
+        self.id = OreSatId.ORESAT0_5
         self.config = OreSatConfig(self.id)


### PR DESCRIPTION
This adds the si41xx lock state to the beacon. True = locked, false = unlocked.