### PR TITLE
Add pdo/cards scripts, script infrastructure changes

### DIFF
--- a/docs/scripts/gen_beacon_rst.py
+++ b/docs/scripts/gen_beacon_rst.py
@@ -10,7 +10,7 @@ sys.path.insert(0, _FILE_PATH)
 import bitstring
 import canopen
 
-from oresat_configs import OreSatConfig, OreSatId
+from oresat_configs import OreSatConfig, Consts
 
 OD_DATA_TYPES = {
     canopen.objectdictionary.BOOLEAN: "bool",
@@ -170,8 +170,8 @@ def gen_beacon_rst(config: OreSatConfig, file_path: str, url: str):
         if obj.name in ["start_chars", "revision"]:
             desc += f": {obj.value}\n"
         if obj.name == "satellite_id":
-            sat_id = OreSatId(obj.value)
-            desc += f": {sat_id.value}\n"
+            sat = Consts.from_id(obj.value)
+            desc += f": {sat.id}\n"
         if obj.value_descriptions:
             desc += "\n\nValue Descriptions:\n"
             for value, descr in obj.value_descriptions.items():
@@ -206,7 +206,7 @@ def gen_beacon_rst_files():
     """Generate all beacon rst files."""
 
     parent_dir = os.path.dirname(os.path.abspath(__file__ + "/.."))
-    for mission in list(OreSatId):
+    for mission in Consts:
         mission_name = mission.name.lower()
         url = (
             f"https://github.com/oresat/oresat-configs/blob/master/oresat_configs/{mission_name}"

--- a/docs/scripts/gen_beacon_rst.py
+++ b/docs/scripts/gen_beacon_rst.py
@@ -10,7 +10,7 @@ sys.path.insert(0, _FILE_PATH)
 import bitstring
 import canopen
 
-from oresat_configs import OreSatConfig, Consts
+from oresat_configs import Consts, OreSatConfig
 
 OD_DATA_TYPES = {
     canopen.objectdictionary.BOOLEAN: "bool",

--- a/oresat_configs/__init__.py
+++ b/oresat_configs/__init__.py
@@ -15,7 +15,7 @@ from ._yaml_to_od import (
 )
 from .base import FW_COMMON_CONFIG_PATH
 from .beacon_config import BeaconConfig
-from .constants import ORESAT_NICE_NAMES, NodeId, OreSatId, __version__
+from .constants import Consts, NodeId, OreSatId, __version__
 from .oresat0 import ORESAT0_BEACON_CONFIG_PATH, ORESAT0_CARD_CONFIGS_PATH
 from .oresat0_5 import ORESAT0_5_BEACON_CONFIG_PATH, ORESAT0_5_CARD_CONFIGS_PATH
 from .oresat1 import ORESAT1_BEACON_CONFIG_PATH, ORESAT1_CARD_CONFIGS_PATH
@@ -55,11 +55,17 @@ class OreSatConfig:
         OreSatId.ORESAT1: ORESAT1_BEACON_CONFIG_PATH,
     }
 
-    def __init__(self, oresat_id: OreSatId):
-        self.oresat_id = oresat_id
-        beacon_config_path = self.BEACON_CONFIG_PATHS[oresat_id]
+    def __init__(self, oresat: OreSatId | Consts | str):
+        if isinstance(oresat, str):
+            oresat = Consts.from_string(oresat)
+        elif isinstance(oresat, OreSatId):
+            oresat = Consts.from_id(oresat)
+        elif not isinstance(oresat, Consts):
+            raise TypeError(f"Unsupported oresat type: '{type(oresat)}'")
+        self.oresat = oresat
+        beacon_config_path = self.BEACON_CONFIG_PATHS[oresat.id]
         beacon_config = BeaconConfig.from_yaml(beacon_config_path)
-        card_configs_path = self.CARD_CONFIG_PATHS[oresat_id]
+        card_configs_path = self.CARD_CONFIG_PATHS[oresat.id]
 
         self.cards = {}
         file_path = f"{os.path.dirname(os.path.abspath(__file__))}/cards.csv"
@@ -79,8 +85,8 @@ class OreSatConfig:
                     )
 
         self.configs = _load_configs(card_configs_path)
-        self.od_db = _gen_od_db(oresat_id, self.cards, beacon_config, self.configs)
+        self.od_db = _gen_od_db(oresat, self.cards, beacon_config, self.configs)
         c3_od = self.od_db["c3"]
         self.beacon_def = _gen_c3_beacon_defs(c3_od, beacon_config)
         self.fram_def = _gen_c3_fram_defs(c3_od, self.configs["c3"])
-        self.fw_base_od = _gen_fw_base_od(oresat_id, FW_COMMON_CONFIG_PATH)
+        self.fw_base_od = _gen_fw_base_od(oresat, FW_COMMON_CONFIG_PATH)

--- a/oresat_configs/__init__.py
+++ b/oresat_configs/__init__.py
@@ -3,6 +3,7 @@
 import csv
 import os
 from dataclasses import dataclass
+from typing import Union
 
 from dataclasses_json import dataclass_json
 
@@ -55,7 +56,7 @@ def cards_from_csv(oresat: Consts) -> dict[str, Card]:
 class OreSatConfig:
     """All the configs for an OreSat mission."""
 
-    def __init__(self, oresat: OreSatId | Consts | str):
+    def __init__(self, oresat: Union[OreSatId, Consts, str]):
         if isinstance(oresat, str):
             oresat = Consts.from_string(oresat)
         elif isinstance(oresat, OreSatId):

--- a/oresat_configs/__init__.py
+++ b/oresat_configs/__init__.py
@@ -43,14 +43,18 @@ def cards_from_csv(oresat: Consts) -> dict[str, Card]:
 
     file_path = f"{os.path.dirname(os.path.abspath(__file__))}/cards.csv"
     with open(file_path, "r") as f:
-        return {row["name"] : Card(
-            row["nice_name"],
-            int(row["node_id"], 16),
-            row["processor"],
-            int(row["opd_address"], 16),
-            row["opd_always_on"].lower() == "true",
-            row["child"],
-        ) for row in csv.DictReader(f) if row["name"] in oresat.cards_path}
+        return {
+            row["name"]: Card(
+                row["nice_name"],
+                int(row["node_id"], 16),
+                row["processor"],
+                int(row["opd_address"], 16),
+                row["opd_always_on"].lower() == "true",
+                row["child"],
+            )
+            for row in csv.DictReader(f)
+            if row["name"] in oresat.cards_path
+        }
 
 
 class OreSatConfig:

--- a/oresat_configs/__init__.py
+++ b/oresat_configs/__init__.py
@@ -38,7 +38,7 @@ class Card:
     """Optional child node name. Useful for CFC cards."""
 
 
-def cards_from_csv(oresat: Consts) -> dict[str, Card]:
+def cards_from_csv(mission: Consts) -> dict[str, Card]:
     """Turns cards.csv into a dict of names->Cards, filtered by the current mission"""
 
     file_path = f"{os.path.dirname(os.path.abspath(__file__))}/cards.csv"
@@ -62,27 +62,35 @@ def cards_from_csv(oresat: Consts) -> dict[str, Card]:
                 row["child"],
             )
             for row in reader
-            if row["name"] in oresat.cards_path
+            if row["name"] in mission.cards_path
         }
 
 
 class OreSatConfig:
     """All the configs for an OreSat mission."""
 
-    def __init__(self, oresat: Union[OreSatId, Consts, str]):
-        if isinstance(oresat, str):
-            oresat = Consts.from_string(oresat)
-        elif isinstance(oresat, OreSatId):
-            oresat = Consts.from_id(oresat)
-        elif not isinstance(oresat, Consts):
-            raise TypeError(f"Unsupported oresat type: '{type(oresat)}'")
+    def __init__(self, mission: Union[OreSatId, Consts, str]):
+        """The parameter mission may be:
+        - a string, either short or long mission name ('0', 'OreSat0.5', ...)
+        - an OreSatId (ORESAT0, ...)
+        - a Consts (ORESAT0, ...)
 
-        self.oresat = oresat
-        beacon_config = BeaconConfig.from_yaml(oresat.beacon_path)
-        self.cards = cards_from_csv(oresat)
-        self.configs = _load_configs(oresat.cards_path)
-        self.od_db = _gen_od_db(oresat, self.cards, beacon_config, self.configs)
+        It will be used to derive the appropriate Consts, the collection of
+        constants associated with a specific oresat mission.
+        """
+        if isinstance(mission, str):
+            mission = Consts.from_string(mission)
+        elif isinstance(mission, OreSatId):
+            mission = Consts.from_id(mission)
+        elif not isinstance(mission, Consts):
+            raise TypeError(f"Unsupported mission type: '{type(mission)}'")
+
+        self.mission = mission
+        beacon_config = BeaconConfig.from_yaml(mission.beacon_path)
+        self.cards = cards_from_csv(mission)
+        self.configs = _load_configs(mission.cards_path)
+        self.od_db = _gen_od_db(mission, self.cards, beacon_config, self.configs)
         c3_od = self.od_db["c3"]
         self.beacon_def = _gen_c3_beacon_defs(c3_od, beacon_config)
         self.fram_def = _gen_c3_fram_defs(c3_od, self.configs["c3"])
-        self.fw_base_od = _gen_fw_base_od(oresat, FW_COMMON_CONFIG_PATH)
+        self.fw_base_od = _gen_fw_base_od(mission, FW_COMMON_CONFIG_PATH)

--- a/oresat_configs/__main__.py
+++ b/oresat_configs/__main__.py
@@ -41,7 +41,7 @@ SCRIPTS = [
 def oresat_configs():
     """oresat_configs main."""
     parser = argparse.ArgumentParser(prog="oresat_configs")
-    parser.add_argument('--version', action='version', version='%(prog)s v' + __version__)
+    parser.add_argument("--version", action="version", version="%(prog)s v" + __version__)
     parser.set_defaults(func=lambda x: parser.print_help())
     subparsers = parser.add_subparsers(title="subcommands")
 

--- a/oresat_configs/__main__.py
+++ b/oresat_configs/__main__.py
@@ -16,6 +16,7 @@ from .scripts import gen_fw_files
 from .scripts import gen_xtce
 from .scripts import print_od
 from .scripts import sdo_transfer
+from .scripts import list_cards
 
 
 SCRIPTS = [
@@ -24,6 +25,7 @@ SCRIPTS = [
     gen_xtce,
     print_od,
     sdo_transfer,
+    list_cards,
 ]
 
 

--- a/oresat_configs/__main__.py
+++ b/oresat_configs/__main__.py
@@ -1,47 +1,45 @@
 """oresat_configs main"""
 
-import sys
+# Process for adding a new script:
+# - Add module to scripts/ directory
+#  - It must have register_subparser() which takes a subparsers list
+# - import the module here and add it to the SCRIPTS list
+# - If it can also be a standalone script then update the pyproject.toml [project.scripts] section
+#
+# test it out - both through oresat_configs and directly
+
+import argparse
 
 from .constants import __version__
-from .scripts.gen_dcf import GEN_DCF, GEN_DCF_PROG, gen_dcf
-from .scripts.gen_fw_files import GEN_FW_FILES, GEN_FW_FILES_PROG, gen_fw_files
-from .scripts.gen_xtce import GEN_XTCE, GEN_XTCE_PROG, gen_xtce
-from .scripts.print_od import PRINT_OD, PRINT_OD_PROG, print_od
-from .scripts.sdo_transfer import SDO_TRANSFER, SDO_TRANSFER_PROG, sdo_transfer
+from .scripts import gen_dcf
+from .scripts import gen_fw_files
+from .scripts import gen_xtce
+from .scripts import print_od
+from .scripts import sdo_transfer
 
-SCRIPTS = {
-    GEN_DCF_PROG: GEN_DCF,
-    GEN_XTCE_PROG: GEN_XTCE,
-    GEN_FW_FILES_PROG: GEN_FW_FILES,
-    PRINT_OD_PROG: PRINT_OD,
-    SDO_TRANSFER_PROG: SDO_TRANSFER,
-}
+
+SCRIPTS = [
+    gen_dcf,
+    gen_fw_files,
+    gen_xtce,
+    print_od,
+    sdo_transfer,
+]
 
 
 def oresat_configs():
     """oresat_configs main."""
+    parser = argparse.ArgumentParser(prog="oresat_configs")
+    parser.add_argument('--version', action='version', version='%(prog)s v' + __version__)
+    parser.set_defaults(func=lambda x: parser.print_help())
+    subparsers = parser.add_subparsers(title="subcommands")
 
-    print("oresat_configs v" + __version__)
-    print("")
+    for subcommand in SCRIPTS:
+        subcommand.register_subparser(subparsers)
 
-    print("command : description")
-    print("--------------------------")
-    for key in SCRIPTS:
-        print(f"{key} : {SCRIPTS[key]}")
+    args = parser.parse_args()
+    args.func(args)
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        oresat_configs()
-    elif sys.argv[1] == GEN_DCF_PROG:
-        gen_dcf(sys.argv[2:])
-    elif sys.argv[1] == GEN_FW_FILES_PROG:
-        gen_fw_files(sys.argv[2:])
-    elif sys.argv[1] == PRINT_OD_PROG:
-        print_od(sys.argv[2:])
-    elif sys.argv[1] == SDO_TRANSFER_PROG:
-        sdo_transfer(sys.argv[2:])
-    elif sys.argv[1] == GEN_XTCE_PROG:
-        gen_xtce(sys.argv[2:])
-    else:
-        oresat_configs()
+    oresat_configs()

--- a/oresat_configs/__main__.py
+++ b/oresat_configs/__main__.py
@@ -11,13 +11,7 @@
 import argparse
 
 from .constants import __version__
-from .scripts import gen_dcf
-from .scripts import gen_fw_files
-from .scripts import gen_xtce
-from .scripts import print_od
-from .scripts import sdo_transfer
-from .scripts import list_cards
-from .scripts import pdo
+from .scripts import gen_dcf, gen_fw_files, gen_xtce, list_cards, pdo, print_od, sdo_transfer
 
 # TODO: Group by three categories in help:
 #   - info (card, od)

--- a/oresat_configs/__main__.py
+++ b/oresat_configs/__main__.py
@@ -17,15 +17,24 @@ from .scripts import gen_xtce
 from .scripts import print_od
 from .scripts import sdo_transfer
 from .scripts import list_cards
+from .scripts import pdo
 
+# TODO: Group by three categories in help:
+#   - info (card, od)
+#   - action (sdo, pdo)
+#   - generate (dcf, xtce, fw)
+# There can only be one subparsers group though, the other groupings
+# would have to be done through add_argument_group() but those can't
+# make subparser groups.
 
 SCRIPTS = [
-    gen_dcf,
-    gen_fw_files,
-    gen_xtce,
+    list_cards,
     print_od,
     sdo_transfer,
-    list_cards,
+    pdo,
+    gen_dcf,
+    gen_xtce,
+    gen_fw_files,
 ]
 
 

--- a/oresat_configs/__main__.py
+++ b/oresat_configs/__main__.py
@@ -1,12 +1,19 @@
-"""oresat_configs main"""
+"""Entry point for for oresat_configs scripts. Invoke with either:
+- python -m oresat_configs
+- oresat-configs
+Some scripts may be installed and run as a standalone program. Consult
+pyproject.toml for names to invoke them with.
 
-# Process for adding a new script:
-# - Add module to scripts/ directory
-#  - It must have register_subparser() which takes a subparsers list
-# - import the module here and add it to the SCRIPTS list
-# - If it can also be a standalone script then update the pyproject.toml [project.scripts] section
-#
-# test it out - both through oresat_configs and directly
+Process for adding a new script:
+- Add as a module to the adjacent scripts/ directory. The module must have the
+  function register_subparser() which takes the output of
+  ArgumentParser.add_subparsers().
+- Import the module here and add it to the _SCRIPTS list.
+- If the script can also be standalone then update the pyproject.toml
+  [project.scripts] section.
+- Test the new script out. Remember that the script may be invoked both through
+  oresat-configs and directly as a standalone.
+"""
 
 import argparse
 
@@ -21,7 +28,7 @@ from .scripts import gen_dcf, gen_fw_files, gen_xtce, list_cards, pdo, print_od,
 # would have to be done through add_argument_group() but those can't
 # make subparser groups.
 
-SCRIPTS = [
+_SCRIPTS = [
     list_cards,
     print_od,
     sdo_transfer,
@@ -32,19 +39,14 @@ SCRIPTS = [
 ]
 
 
-def oresat_configs():
-    """oresat_configs main."""
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog="oresat_configs")
     parser.add_argument("--version", action="version", version="%(prog)s v" + __version__)
     parser.set_defaults(func=lambda x: parser.print_help())
     subparsers = parser.add_subparsers(title="subcommands")
 
-    for subcommand in SCRIPTS:
+    for subcommand in _SCRIPTS:
         subcommand.register_subparser(subparsers)
 
     args = parser.parse_args()
     args.func(args)
-
-
-if __name__ == "__main__":
-    oresat_configs()

--- a/oresat_configs/_yaml_to_od.py
+++ b/oresat_configs/_yaml_to_od.py
@@ -564,7 +564,7 @@ def _load_configs(config_paths: dict) -> Dict[str, CardConfig]:
     return configs
 
 
-def _gen_od_db(oresat: Consts, cards: dict, beacon_def: BeaconConfig, configs: dict) -> dict:
+def _gen_od_db(mission: Consts, cards: dict, beacon_def: BeaconConfig, configs: dict) -> dict:
     od_db = {}
     node_ids = {name: cards[name].node_id for name in configs}
     node_ids["c3"] = 0x1
@@ -606,7 +606,7 @@ def _gen_od_db(oresat: Consts, cards: dict, beacon_def: BeaconConfig, configs: d
 
         # set specific obj defaults
         od["versions"]["configs_version"].default = __version__
-        od["satellite_id"].default = oresat.id
+        od["satellite_id"].default = mission.id
         for sat in Consts:
             od["satellite_id"].value_descriptions[sat.id] = sat.name.lower()
         if name == "c3":
@@ -672,7 +672,7 @@ def _gen_c3_beacon_defs(c3_od: canopen.ObjectDictionary, beacon_def: BeaconConfi
     return beacon_objs
 
 
-def _gen_fw_base_od(oresat: Consts, config_path: str) -> canopen.ObjectDictionary:
+def _gen_fw_base_od(mission: Consts, config_path: str) -> canopen.ObjectDictionary:
     """Generate all ODs for a OreSat mission."""
 
     od = canopen.ObjectDictionary()
@@ -709,6 +709,6 @@ def _gen_fw_base_od(oresat: Consts, config_path: str) -> canopen.ObjectDictionar
 
     # set specific obj defaults
     od["versions"]["configs_version"].default = __version__
-    od["satellite_id"].default = oresat.id
+    od["satellite_id"].default = mission.id
 
     return od

--- a/oresat_configs/_yaml_to_od.py
+++ b/oresat_configs/_yaml_to_od.py
@@ -14,7 +14,7 @@ except ImportError:
 
 from .beacon_config import BeaconConfig
 from .card_config import CardConfig, IndexObject
-from .constants import OreSatId, __version__
+from .constants import Consts, __version__
 
 STD_OBJS_FILE_NAME = f"{os.path.dirname(os.path.abspath(__file__))}/standard_objects.yaml"
 
@@ -564,7 +564,7 @@ def _load_configs(config_paths: dict) -> Dict[str, CardConfig]:
     return configs
 
 
-def _gen_od_db(oresat_id: OreSatId, cards: dict, beacon_def: BeaconConfig, configs: dict) -> dict:
+def _gen_od_db(oresat: Consts, cards: dict, beacon_def: BeaconConfig, configs: dict) -> dict:
     od_db = {}
     node_ids = {name: cards[name].node_id for name in configs}
     node_ids["c3"] = 0x1
@@ -606,9 +606,9 @@ def _gen_od_db(oresat_id: OreSatId, cards: dict, beacon_def: BeaconConfig, confi
 
         # set specific obj defaults
         od["versions"]["configs_version"].default = __version__
-        od["satellite_id"].default = oresat_id.value
-        for oid in list(OreSatId):
-            od["satellite_id"].value_descriptions[oid.value] = oid.name.lower()
+        od["satellite_id"].default = oresat.id
+        for sat in Consts:
+            od["satellite_id"].value_descriptions[sat.id] = sat.name.lower()
         if name == "c3":
             od["beacon"]["revision"].default = beacon_def.revision
             od["beacon"]["dest_callsign"].default = beacon_def.ax25.dest_callsign
@@ -672,7 +672,7 @@ def _gen_c3_beacon_defs(c3_od: canopen.ObjectDictionary, beacon_def: BeaconConfi
     return beacon_objs
 
 
-def _gen_fw_base_od(oresat_id: OreSatId, config_path: str) -> canopen.ObjectDictionary:
+def _gen_fw_base_od(oresat: Consts, config_path: str) -> canopen.ObjectDictionary:
     """Generate all ODs for a OreSat mission."""
 
     od = canopen.ObjectDictionary()
@@ -709,6 +709,6 @@ def _gen_fw_base_od(oresat_id: OreSatId, config_path: str) -> canopen.ObjectDict
 
     # set specific obj defaults
     od["versions"]["configs_version"].default = __version__
-    od["satellite_id"].default = oresat_id.value
+    od["satellite_id"].default = oresat.id
 
     return od

--- a/oresat_configs/constants.py
+++ b/oresat_configs/constants.py
@@ -4,25 +4,69 @@ OreSat OD constants
 Seperate from __init__.py to avoid cirular imports.
 """
 
-from enum import IntEnum
+from __future__ import annotations
+from dataclasses import dataclass
+from enum import Enum, IntEnum, unique
 
 __version__ = "0.3.1"
 
 
+@dataclass
+class Mission:
+    """A specific set of constants associated with an OreSat Mission"""
+    id: int
+    arg: str
+
+
+@unique
+class Consts(Mission, Enum):
+    """Constants associated with each OreSat Mission"""
+    ORESAT0 = 1, "0"
+    ORESAT0_5 = 2, "0.5"
+    ORESAT1 = 3, "1"
+
+    def __str__(self) -> str:
+        return "OreSat" + self.arg
+
+    @classmethod
+    def default(cls) -> Consts:
+        """Returns the currently active mission"""
+        return cls.ORESAT0_5
+
+    @classmethod
+    def from_string(cls, val: str) -> Consts:
+        """Fetches the Mission associated with an appropriate string
+
+        Appropriate strings are the arg (0, 0.5, ...), optionally prefixed with
+        OreSat or oresat
+        """
+        arg = val.lower().removeprefix("oresat")
+        for m in cls:
+            if m.arg == arg:
+                return m
+        raise ValueError(f"invalid oresat mission: {val}")
+
+    @classmethod
+    def from_id(cls, val: OreSatId | int) -> Consts:
+        """Fetches the Mission associated with an integer ID"""
+        if isinstance(val, OreSatId):
+            val = val.value
+        elif not isinstance(val, int):
+            raise TypeError(f"Unsupported val type: '{type(val)}'")
+
+        for m in cls:
+            if m.id == val:
+                return m
+        raise ValueError(f"invalid OreSatId: {val}")
+
+
+@unique
 class OreSatId(IntEnum):
     """Unique ID for each OreSat."""
 
     ORESAT0 = 1
     ORESAT0_5 = 2
     ORESAT1 = 3
-
-
-ORESAT_NICE_NAMES = {
-    OreSatId.ORESAT0: "OreSat0",
-    OreSatId.ORESAT0_5: "OreSat0.5",
-    OreSatId.ORESAT1: "OreSat1",
-}
-"""Nice name for OreSat missions."""
 
 
 class NodeId(IntEnum):

--- a/oresat_configs/constants.py
+++ b/oresat_configs/constants.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum, IntEnum, unique
 
+from . import oresat0, oresat0_5, oresat1
+
 __version__ = "0.3.1"
 
 
@@ -16,14 +18,16 @@ class Mission:
     """A specific set of constants associated with an OreSat Mission"""
     id: int
     arg: str
+    beacon_path: str
+    cards_path: dict[str, tuple[str, ...] | None]
 
 
 @unique
 class Consts(Mission, Enum):
     """Constants associated with each OreSat Mission"""
-    ORESAT0 = 1, "0"
-    ORESAT0_5 = 2, "0.5"
-    ORESAT1 = 3, "1"
+    ORESAT0 = 1, "0", oresat0.BEACON_CONFIG_PATH, oresat0.CARD_CONFIGS_PATH
+    ORESAT0_5 = 2, "0.5", oresat0_5.BEACON_CONFIG_PATH, oresat0_5.CARD_CONFIGS_PATH
+    ORESAT1 = 3, "1", oresat1.BEACON_CONFIG_PATH, oresat1.CARD_CONFIGS_PATH
 
     def __str__(self) -> str:
         return "OreSat" + self.arg

--- a/oresat_configs/constants.py
+++ b/oresat_configs/constants.py
@@ -16,6 +16,7 @@ __version__ = "0.3.1"
 @dataclass
 class Mission:
     """A specific set of constants associated with an OreSat Mission"""
+
     id: int
     arg: str
     beacon_path: str
@@ -25,6 +26,7 @@ class Mission:
 @unique
 class Consts(Mission, Enum):
     """Constants associated with each OreSat Mission"""
+
     ORESAT0 = 1, "0", oresat0.BEACON_CONFIG_PATH, oresat0.CARD_CONFIGS_PATH
     ORESAT0_5 = 2, "0.5", oresat0_5.BEACON_CONFIG_PATH, oresat0_5.CARD_CONFIGS_PATH
     ORESAT1 = 3, "1", oresat1.BEACON_CONFIG_PATH, oresat1.CARD_CONFIGS_PATH

--- a/oresat_configs/constants.py
+++ b/oresat_configs/constants.py
@@ -5,6 +5,7 @@ Seperate from __init__.py to avoid cirular imports.
 """
 
 from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum, IntEnum, unique
 

--- a/oresat_configs/oresat0/__init__.py
+++ b/oresat_configs/oresat0/__init__.py
@@ -1,6 +1,7 @@
 """OreSat0 object dictionary and beacon constants."""
 
 import os
+from typing import Optional
 
 from ..base import (
     BAT_CONFIG_PATH,
@@ -20,7 +21,7 @@ BAT_OVERLAY_CONFIG_PATH = f"{_CONFIGS_DIR}/battery_overlay.yaml"
 
 BEACON_CONFIG_PATH: str = f"{_CONFIGS_DIR}/beacon.yaml"
 
-CARD_CONFIGS_PATH: dict[str, tuple[str, ...] | None] = {
+CARD_CONFIGS_PATH: dict[str, Optional[tuple[str, ...]]] = {
     "c3": (C3_CONFIG_PATH, SW_COMMON_CONFIG_PATH),
     "battery_1": (BAT_CONFIG_PATH, FW_COMMON_CONFIG_PATH, BAT_OVERLAY_CONFIG_PATH),
     "solar_1": (SOLAR_CONFIG_PATH, FW_COMMON_CONFIG_PATH),

--- a/oresat_configs/oresat0/__init__.py
+++ b/oresat_configs/oresat0/__init__.py
@@ -18,9 +18,9 @@ _CONFIGS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 BAT_OVERLAY_CONFIG_PATH = f"{_CONFIGS_DIR}/battery_overlay.yaml"
 
-ORESAT0_BEACON_CONFIG_PATH = f"{_CONFIGS_DIR}/beacon.yaml"
+BEACON_CONFIG_PATH: str = f"{_CONFIGS_DIR}/beacon.yaml"
 
-ORESAT0_CARD_CONFIGS_PATH = {
+CARD_CONFIGS_PATH: dict[str, tuple[str, ...] | None] = {
     "c3": (C3_CONFIG_PATH, SW_COMMON_CONFIG_PATH),
     "battery_1": (BAT_CONFIG_PATH, FW_COMMON_CONFIG_PATH, BAT_OVERLAY_CONFIG_PATH),
     "solar_1": (SOLAR_CONFIG_PATH, FW_COMMON_CONFIG_PATH),

--- a/oresat_configs/oresat0_5/__init__.py
+++ b/oresat_configs/oresat0_5/__init__.py
@@ -1,6 +1,7 @@
 """OreSat0.5 object dictionary and beacon constants."""
 
 import os
+from typing import Optional
 
 from ..base import (
     BAT_CONFIG_PATH,
@@ -20,7 +21,7 @@ _CONFIGS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 BEACON_CONFIG_PATH: str = f"{_CONFIGS_DIR}/beacon.yaml"
 
-CARD_CONFIGS_PATH: dict[str, tuple[str, ...] | None] = {
+CARD_CONFIGS_PATH: dict[str, Optional[tuple[str, ...]]] = {
     "c3": (C3_CONFIG_PATH, SW_COMMON_CONFIG_PATH),
     "battery_1": (BAT_CONFIG_PATH, FW_COMMON_CONFIG_PATH),
     "solar_1": (SOLAR_CONFIG_PATH, FW_COMMON_CONFIG_PATH),

--- a/oresat_configs/oresat0_5/__init__.py
+++ b/oresat_configs/oresat0_5/__init__.py
@@ -18,9 +18,9 @@ from ..base import (
 
 _CONFIGS_DIR = os.path.dirname(os.path.abspath(__file__))
 
-ORESAT0_5_BEACON_CONFIG_PATH = f"{_CONFIGS_DIR}/beacon.yaml"
+BEACON_CONFIG_PATH: str = f"{_CONFIGS_DIR}/beacon.yaml"
 
-ORESAT0_5_CARD_CONFIGS_PATH = {
+CARD_CONFIGS_PATH: dict[str, tuple[str, ...] | None] = {
     "c3": (C3_CONFIG_PATH, SW_COMMON_CONFIG_PATH),
     "battery_1": (BAT_CONFIG_PATH, FW_COMMON_CONFIG_PATH),
     "solar_1": (SOLAR_CONFIG_PATH, FW_COMMON_CONFIG_PATH),

--- a/oresat_configs/oresat1/__init__.py
+++ b/oresat_configs/oresat1/__init__.py
@@ -1,6 +1,7 @@
 """OreSat1 object dictionary and beacon constants."""
 
 import os
+from typing import Optional
 
 from ..base import (
     BAT_CONFIG_PATH,
@@ -20,7 +21,7 @@ _CONFIGS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 BEACON_CONFIG_PATH: str = f"{_CONFIGS_DIR}/beacon.yaml"
 
-CARD_CONFIGS_PATH: dict[str, tuple[str, ...] | None] = {
+CARD_CONFIGS_PATH: dict[str, Optional[tuple[str, ...]]] = {
     "c3": (C3_CONFIG_PATH, SW_COMMON_CONFIG_PATH),
     "battery_1": (BAT_CONFIG_PATH, FW_COMMON_CONFIG_PATH),
     "battery_2": (BAT_CONFIG_PATH, FW_COMMON_CONFIG_PATH),

--- a/oresat_configs/oresat1/__init__.py
+++ b/oresat_configs/oresat1/__init__.py
@@ -18,9 +18,9 @@ from ..base import (
 
 _CONFIGS_DIR = os.path.dirname(os.path.abspath(__file__))
 
-ORESAT1_BEACON_CONFIG_PATH = f"{_CONFIGS_DIR}/beacon.yaml"
+BEACON_CONFIG_PATH: str = f"{_CONFIGS_DIR}/beacon.yaml"
 
-ORESAT1_CARD_CONFIGS_PATH = {
+CARD_CONFIGS_PATH: dict[str, tuple[str, ...] | None] = {
     "c3": (C3_CONFIG_PATH, SW_COMMON_CONFIG_PATH),
     "battery_1": (BAT_CONFIG_PATH, FW_COMMON_CONFIG_PATH),
     "battery_2": (BAT_CONFIG_PATH, FW_COMMON_CONFIG_PATH),

--- a/oresat_configs/scripts/gen_dcf.py
+++ b/oresat_configs/scripts/gen_dcf.py
@@ -1,13 +1,12 @@
 """Generate a DCF for from an OreSat card's object directory."""
 
-import sys
 from argparse import ArgumentParser, Namespace
 from datetime import datetime
 from typing import Optional
 
 import canopen
 
-from .. import OreSatConfig, OreSatId
+from .. import OreSatConfig, Consts
 
 GEN_DCF = "generate DCF file for OreSat node(s)"
 GEN_DCF_PROG = "oresat-gen-dcf"
@@ -19,9 +18,9 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
     """
     parser.description = GEN_DCF
-    parser.add_argument(
-        "oresat", default="oresat0", help="oresat mission; oresat0, oresat0.5, or oresat1"
-    )
+    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
+                        type=lambda x: x.lower().removeprefix("oresat"),
+                        help="oresat mission, defaults to %(default)s")
     parser.add_argument("card", help="card name; all, c3, gps, star_tracker_1, etc")
     parser.add_argument("-d", "--dir-path", default=".", help='directory path; defautl "."')
     return parser
@@ -242,18 +241,7 @@ def gen_dcf(args: Optional[Namespace] = None):
     if args is None:
         args = build_parser(ArgumentParser()).parse_args()
 
-    arg_oresat = args.oresat.lower()
-    if arg_oresat in ["0", "oresat0"]:
-        oresat_id = OreSatId.ORESAT0
-    elif arg_oresat in ["0.5", "oresat0.5"]:
-        oresat_id = OreSatId.ORESAT0_5
-    elif arg_oresat in ["1", "oresat1"]:
-        oresat_id = OreSatId.ORESAT1
-    else:
-        print(f"invalid oresat mission: {args.oresat}")
-        sys.exit()
-
-    config = OreSatConfig(oresat_id)
+    config = OreSatConfig(args.oresat)
 
     if args.card.lower() == "all":
         for od in config.od_db.values():

--- a/oresat_configs/scripts/gen_dcf.py
+++ b/oresat_configs/scripts/gen_dcf.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import canopen
 
-from .. import OreSatConfig, Consts
+from .. import Consts, OreSatConfig
 
 GEN_DCF = "generate DCF file for OreSat node(s)"
 

--- a/oresat_configs/scripts/gen_dcf.py
+++ b/oresat_configs/scripts/gen_dcf.py
@@ -9,7 +9,6 @@ import canopen
 from .. import OreSatConfig, Consts
 
 GEN_DCF = "generate DCF file for OreSat node(s)"
-GEN_DCF_PROG = "oresat-gen-dcf"
 
 
 def build_parser(parser: ArgumentParser) -> ArgumentParser:
@@ -36,7 +35,7 @@ def register_subparser(subparsers):
     See https://docs.python.org/3/library/argparse.html#sub-commands, especially the end of that
     section, for more.
     """
-    parser = build_parser(subparsers.add_parser(GEN_DCF_PROG, help=GEN_DCF))
+    parser = build_parser(subparsers.add_parser("dcf", help=GEN_DCF))
     parser.set_defaults(func=gen_dcf)
 
 

--- a/oresat_configs/scripts/gen_dcf.py
+++ b/oresat_configs/scripts/gen_dcf.py
@@ -1,8 +1,9 @@
 """Generate a DCF for from an OreSat card's object directory."""
 
 import sys
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
 from datetime import datetime
+from typing import Optional
 
 import canopen
 
@@ -10,6 +11,34 @@ from .. import OreSatConfig, OreSatId
 
 GEN_DCF = "generate DCF file for OreSat node(s)"
 GEN_DCF_PROG = "oresat-gen-dcf"
+
+
+def build_parser(parser: ArgumentParser) -> ArgumentParser:
+    """Configures an ArgumentParser suitable for this script.
+
+    The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
+    """
+    parser.description = GEN_DCF
+    parser.add_argument(
+        "oresat", default="oresat0", help="oresat mission; oresat0, oresat0.5, or oresat1"
+    )
+    parser.add_argument("card", help="card name; all, c3, gps, star_tracker_1, etc")
+    parser.add_argument("-d", "--dir-path", default=".", help='directory path; defautl "."')
+    return parser
+
+
+def register_subparser(subparsers):
+    """Registers an ArgumentParser as a subcommand of another parser.
+
+    Intended to be called by __main__.py for each script. Given the output of add_subparsers(),
+    (which I think is a subparser group, but is technically unspecified) this function should
+    create its own ArgumentParser via add_parser(). It must also set_default() the func argument
+    to designate the entry point into this script.
+    See https://docs.python.org/3/library/argparse.html#sub-commands, especially the end of that
+    section, for more.
+    """
+    parser = build_parser(subparsers.add_parser(GEN_DCF_PROG, help=GEN_DCF))
+    parser.set_defaults(func=gen_dcf)
 
 
 def write_od(od: canopen.ObjectDictionary, dir_path: str = "."):
@@ -208,19 +237,10 @@ def _record_lines(record: canopen.objectdictionary.Record, index: int) -> list:
     return lines
 
 
-def gen_dcf(sys_args=None):
+def gen_dcf(args: Optional[Namespace] = None):
     """Gen_dcf main."""
-
-    if sys_args is None:
-        sys_args = sys.argv[1:]
-
-    parser = ArgumentParser(description=GEN_DCF, prog=GEN_DCF_PROG)
-    parser.add_argument(
-        "oresat", default="oresat0", help="oresat mission; oresat0, oresat0.5, or oresat1"
-    )
-    parser.add_argument("card", help="card name; all, c3, gps, star_tracker_1, etc")
-    parser.add_argument("-d", "--dir-path", default=".", help='directory path; defautl "."')
-    args = parser.parse_args(sys_args)
+    if args is None:
+        args = build_parser(ArgumentParser()).parse_args()
 
     arg_oresat = args.oresat.lower()
     if arg_oresat in ["0", "oresat0"]:

--- a/oresat_configs/scripts/gen_dcf.py
+++ b/oresat_configs/scripts/gen_dcf.py
@@ -17,9 +17,13 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
     """
     parser.description = GEN_DCF
-    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
-                        type=lambda x: x.lower().removeprefix("oresat"),
-                        help="oresat mission, defaults to %(default)s")
+    parser.add_argument(
+        "--oresat",
+        default=Consts.default().arg,
+        choices=[m.arg for m in Consts],
+        type=lambda x: x.lower().removeprefix("oresat"),
+        help="oresat mission, defaults to %(default)s",
+    )
     parser.add_argument("card", help="card name; all, c3, gps, star_tracker_1, etc")
     parser.add_argument("-d", "--dir-path", default=".", help='directory path; defautl "."')
     return parser

--- a/oresat_configs/scripts/gen_fw_files.py
+++ b/oresat_configs/scripts/gen_fw_files.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import canopen
 
-from .. import OreSatConfig, Consts
+from .. import Consts, OreSatConfig
 
 GEN_FW_FILES = "generate CANopenNode OD.[c/h] files for a OreSat firmware card"
 

--- a/oresat_configs/scripts/gen_fw_files.py
+++ b/oresat_configs/scripts/gen_fw_files.py
@@ -19,9 +19,13 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
     """
     parser.description = GEN_FW_FILES
-    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
-                        type=lambda x: x.lower().removeprefix("oresat"),
-                        help="oresat mission, defaults to %(default)s")
+    parser.add_argument(
+        "--oresat",
+        default=Consts.default().arg,
+        choices=[m.arg for m in Consts],
+        type=lambda x: x.lower().removeprefix("oresat"),
+        help="oresat mission, defaults to %(default)s",
+    )
     parser.add_argument("card", help="card name; c3, battery, solar, imu, or reaction_wheel")
     parser.add_argument("-d", "--dir-path", default=".", help='output directory path, default: "."')
     return parser

--- a/oresat_configs/scripts/gen_fw_files.py
+++ b/oresat_configs/scripts/gen_fw_files.py
@@ -11,7 +11,6 @@ import canopen
 from .. import OreSatConfig, Consts
 
 GEN_FW_FILES = "generate CANopenNode OD.[c/h] files for a OreSat firmware card"
-GEN_FW_FILES_PROG = "oresat-gen-fw-files"
 
 
 def build_parser(parser: ArgumentParser) -> ArgumentParser:
@@ -38,7 +37,7 @@ def register_subparser(subparsers):
     See https://docs.python.org/3/library/argparse.html#sub-commands, especially the end of that
     section, for more.
     """
-    parser = build_parser(subparsers.add_parser(GEN_FW_FILES_PROG, help=GEN_FW_FILES))
+    parser = build_parser(subparsers.add_parser("fw-files", help=GEN_FW_FILES))
     parser.set_defaults(func=gen_fw_files)
 
 

--- a/oresat_configs/scripts/gen_fw_files.py
+++ b/oresat_configs/scripts/gen_fw_files.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import canopen
 
-from .. import OreSatConfig, OreSatId
+from .. import OreSatConfig, Consts
 
 GEN_FW_FILES = "generate CANopenNode OD.[c/h] files for a OreSat firmware card"
 GEN_FW_FILES_PROG = "oresat-gen-fw-files"
@@ -20,7 +20,9 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
     """
     parser.description = GEN_FW_FILES
-    parser.add_argument("oresat", help="oresat mission; oresat0 or oresat0.5")
+    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
+                        type=lambda x: x.lower().removeprefix("oresat"),
+                        help="oresat mission, defaults to %(default)s")
     parser.add_argument("card", help="card name; c3, battery, solar, imu, or reaction_wheel")
     parser.add_argument("-d", "--dir-path", default=".", help='output directory path, default: "."')
     return parser
@@ -678,18 +680,7 @@ def gen_fw_files(args: Optional[Namespace] = None):
     if args is None:
         args = build_parser(ArgumentParser()).parse_args()
 
-    arg_oresat = args.oresat.lower()
-    if arg_oresat in ["0", "oresat0"]:
-        oresat_id = OreSatId.ORESAT0
-    elif arg_oresat in ["0.5", "oresat0.5"]:
-        oresat_id = OreSatId.ORESAT0_5
-    elif arg_oresat in ["1", "oresat1"]:
-        oresat_id = OreSatId.ORESAT1
-    else:
-        print(f"invalid oresat mission: {args.oresat}")
-        sys.exit()
-
-    config = OreSatConfig(oresat_id)
+    config = OreSatConfig(args.oresat)
 
     arg_card = args.card.lower().replace("-", "_")
     if arg_card == "c3":

--- a/oresat_configs/scripts/gen_xtce.py
+++ b/oresat_configs/scripts/gen_xtce.py
@@ -117,7 +117,7 @@ def write_xtce(config: OreSatConfig, dir_path: str = "."):
     root = ET.Element(
         "SpaceSystem",
         attrib={
-            "name": str(config.oresat),
+            "name": str(config.mission),
             "xmlns:xtce": "http://www.omg.org/space/xtce",
             "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
             "xsi:schemaLocation": (
@@ -340,7 +340,7 @@ def write_xtce(config: OreSatConfig, dir_path: str = "."):
     # write
     tree = ET.ElementTree(root)
     ET.indent(tree, space="  ", level=0)
-    file_name = f"{config.oresat.name.lower()}.xtce"
+    file_name = f"{config.mission.name.lower()}.xtce"
     tree.write(f"{dir_path}/{file_name}", encoding="utf-8", xml_declaration=True)
 
 

--- a/oresat_configs/scripts/gen_xtce.py
+++ b/oresat_configs/scripts/gen_xtce.py
@@ -10,7 +10,6 @@ import canopen
 from .. import OreSatConfig, Consts
 
 GEN_XTCE = "generate beacon xtce file"
-GEN_XTCE_PROG = "oresat-gen-xtce"
 
 
 def build_parser(parser: ArgumentParser) -> ArgumentParser:
@@ -36,7 +35,7 @@ def register_subparser(subparsers):
     See https://docs.python.org/3/library/argparse.html#sub-commands, especially the end of that
     section, for more.
     """
-    parser = build_parser(subparsers.add_parser(GEN_XTCE_PROG, help=GEN_XTCE))
+    parser = build_parser(subparsers.add_parser("xtce", help=GEN_XTCE))
     parser.set_defaults(func=gen_xtce)
 
 

--- a/oresat_configs/scripts/gen_xtce.py
+++ b/oresat_configs/scripts/gen_xtce.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import canopen
 
-from .. import OreSatConfig, Consts
+from .. import Consts, OreSatConfig
 
 GEN_XTCE = "generate beacon xtce file"
 

--- a/oresat_configs/scripts/gen_xtce.py
+++ b/oresat_configs/scripts/gen_xtce.py
@@ -18,9 +18,13 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
     """
     parser.description = GEN_XTCE
-    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
-                        type=lambda x: x.lower().removeprefix("oresat"),
-                        help="oresat mission, defaults to %(default)s")
+    parser.add_argument(
+        "--oresat",
+        default=Consts.default().arg,
+        choices=[m.arg for m in Consts],
+        type=lambda x: x.lower().removeprefix("oresat"),
+        help="oresat mission, defaults to %(default)s",
+    )
     parser.add_argument("-d", "--dir-path", default=".", help='directory path; defautl "."')
     return parser
 

--- a/oresat_configs/scripts/list_cards.py
+++ b/oresat_configs/scripts/list_cards.py
@@ -18,9 +18,13 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     """
     parser.description = LIST_CARDS
     parser.formatter_class = RawDescriptionHelpFormatter
-    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
-                        type=lambda x: x.lower().removeprefix("oresat"),
-                        help="oresat mission, defaults to %(default)s")
+    parser.add_argument(
+        "--oresat",
+        default=Consts.default().arg,
+        choices=[m.arg for m in Consts],
+        type=lambda x: x.lower().removeprefix("oresat"),
+        help="oresat mission, defaults to %(default)s",
+    )
     # I'd like to pull the descriptions directly out of Card but attribute docstrings are discarded
     # and not accessable at runtime.
     rows = [

--- a/oresat_configs/scripts/list_cards.py
+++ b/oresat_configs/scripts/list_cards.py
@@ -1,0 +1,73 @@
+"""Prints the known list of oresat cards"""
+
+from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
+from collections import defaultdict
+from dataclasses import fields, asdict
+from tabulate import tabulate
+
+from .. import cards_from_csv, Consts, Card
+
+LIST_CARDS = "list oresat cards, suitable as arguments to other commands"
+
+
+def build_parser(parser: ArgumentParser) -> ArgumentParser:
+    """Configures an ArgumentParser suitable for this script.
+
+    The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
+    """
+    parser.description = LIST_CARDS
+    parser.formatter_class = RawDescriptionHelpFormatter
+    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
+                        type=lambda x: x.lower().removeprefix("oresat"),
+                        help="oresat mission, defaults to %(default)s")
+    # I'd like to pull the descriptions directly out of Card but attribute docstrings are discarded
+    # and not accessable at runtime.
+    rows = [
+        ["name", "The canonical name, suitable for arguments of other scripts"],
+        ["nice_name", "A nice name for the card"],
+        ["node_id", "CANopen node id"],
+        ["processor", 'Processor type; e.g.: "octavo", "stm32", or "none"'],
+        ["opd_address", "OPD address"],
+        ["opd_always_on", "Keep the card on all the time. Only for battery cards"],
+        ["child", "Optional child node name. Useful for CFC cards."],
+    ]
+    parser.epilog = "Columns:\n" + tabulate(rows)
+    missing = {f.name for f in fields(Card)} - {r[0] for r in rows}
+    if missing:
+        parser.epilog += f"\nColums missing description: {missing}"
+
+    return parser
+
+
+def register_subparser(subparsers):
+    """Registers an ArgumentParser as a subcommand of another parser.
+
+    Intended to be called by __main__.py for each script. Given the output of add_subparsers(),
+    (which I think is a subparser group, but is technically unspecified) this function should
+    create its own ArgumentParser via add_parser(). It must also set_default() the func argument
+    to designate the entry point into this script.
+    See https://docs.python.org/3/library/argparse.html#sub-commands, especially the end of that
+    section, for more.
+    """
+    parser = build_parser(subparsers.add_parser("cards", help=LIST_CARDS))
+    parser.set_defaults(func=list_cards)
+
+
+def list_cards(args: Namespace | None = None):
+    """Lists oresat cards and their configurations"""
+    if args is None:
+        args = build_parser(ArgumentParser()).parse_args()
+
+    cards = cards_from_csv(Consts.from_string(args.oresat))
+    data = defaultdict(list)
+    data["name"] = cards.keys()
+    for card in cards.values():
+        for key, value in asdict(card).items():
+            if key == "node_id":
+                value = f"0x{value:02X}" if value else ""
+            elif key == "opd_address":
+                value = f"0x{value:02X}" if value else ""
+            elif key == "opd_always_on":
+                value = "True" if value else ""
+            data[key].append(value)
+    print(tabulate(data, headers="keys"))

--- a/oresat_configs/scripts/list_cards.py
+++ b/oresat_configs/scripts/list_cards.py
@@ -2,11 +2,12 @@
 
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 from collections import defaultdict
-from dataclasses import fields, asdict
+from dataclasses import asdict, fields
 from typing import Optional
+
 from tabulate import tabulate
 
-from .. import cards_from_csv, Consts, Card
+from .. import Card, Consts, cards_from_csv
 
 LIST_CARDS = "list oresat cards, suitable as arguments to other commands"
 

--- a/oresat_configs/scripts/list_cards.py
+++ b/oresat_configs/scripts/list_cards.py
@@ -3,6 +3,7 @@
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 from collections import defaultdict
 from dataclasses import fields, asdict
+from typing import Optional
 from tabulate import tabulate
 
 from .. import cards_from_csv, Consts, Card
@@ -53,7 +54,7 @@ def register_subparser(subparsers):
     parser.set_defaults(func=list_cards)
 
 
-def list_cards(args: Namespace | None = None):
+def list_cards(args: Optional[Namespace] = None):
     """Lists oresat cards and their configurations"""
     if args is None:
         args = build_parser(ArgumentParser()).parse_args()

--- a/oresat_configs/scripts/pdo.py
+++ b/oresat_configs/scripts/pdo.py
@@ -2,6 +2,7 @@
 
 from argparse import ArgumentParser, Namespace
 import time
+from typing import Optional
 import canopen
 
 from .. import OreSatConfig, Consts
@@ -126,7 +127,7 @@ def listpdos(node_id: int, od: canopen.ObjectDictionary):
         print(f"PDO {index:2} {pdo.cob_id:03X} ({ttype}) => {names}")
 
 
-def pdo_main(args: Namespace | None = None):
+def pdo_main(args: Optional[Namespace] = None):
     """The utility for managing PDOs"""
     if args is None:
         args = build_parser(ArgumentParser()).parse_args()

--- a/oresat_configs/scripts/pdo.py
+++ b/oresat_configs/scripts/pdo.py
@@ -1,0 +1,141 @@
+"""Tools for working with PDOs"""
+
+from argparse import ArgumentParser, Namespace
+import time
+import canopen
+
+from .. import OreSatConfig, Consts
+
+
+PDO = "list or receive PDOs from the specified card"
+
+
+def build_parser(parser: ArgumentParser) -> ArgumentParser:
+    """Configures an ArgumentParser suitable for this script.
+
+    The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
+    """
+    parser.description = PDO
+    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
+                        type=lambda x: x.lower().removeprefix("oresat"),
+                        help="oresat mission, defaults to %(default)s")
+    parser.add_argument("card", help="card name")
+    parser.add_argument("--list", action="store_true",
+                        help="list PDOs expected for the particular card")
+    parser.add_argument("--bus", default="vcan0",
+                        help="CAN bus to listen on, defaults to %(default)s")
+    return parser
+
+
+def register_subparser(subparsers):
+    """Registers an ArgumentParser as a subcommand of another parser.
+
+    Intended to be called by __main__.py for each script. Given the output of add_subparsers(),
+    (which I think is a subparser group, but is technically unspecified) this function should
+    create its own ArgumentParser via add_parser(). It must also set_default() the func argument
+    to designate the entry point into this script.
+    See https://docs.python.org/3/library/argparse.html#sub-commands, especially the end of that
+    section, for more.
+    """
+    parser = build_parser(subparsers.add_parser("pdo", help=PDO))
+    parser.set_defaults(func=pdo_main)
+
+
+typenames = {
+    canopen.objectdictionary.BOOLEAN: 'bool',
+    canopen.objectdictionary.INTEGER8: 'i8',
+    canopen.objectdictionary.INTEGER16: 'i16',
+    canopen.objectdictionary.INTEGER32: 'i32',
+    canopen.objectdictionary.UNSIGNED8: 'u8',
+    canopen.objectdictionary.UNSIGNED16: 'u16',
+    canopen.objectdictionary.UNSIGNED32: 'u32',
+    canopen.objectdictionary.REAL32: 'f32',
+    canopen.objectdictionary.VISIBLE_STRING: 'str',
+    canopen.objectdictionary.OCTET_STRING: 'bytes',
+    canopen.objectdictionary.UNICODE_STRING: 'ustr',
+    canopen.objectdictionary.DOMAIN: 'domain',
+    # canopen.objectdictionary.INTEGER24: 'i24',
+    canopen.objectdictionary.REAL64: 'f64',
+    canopen.objectdictionary.INTEGER64: 'i64',
+    # canopen.objectdictionary.UNSIGNED24: 'u24',
+    canopen.objectdictionary.UNSIGNED64: 'u64',
+}
+
+
+def transmission_type(t: int) -> str:
+    """Retreives a name for a TPDO Transmission type
+
+    Subindex 2 of a PDO communication parameter record. See CiA-301 table 72.
+    """
+    if 0 <= t < 0xF0:
+        return f"sync ({t})"
+    if 0xF0 < t < 0xFB:
+        return "reserved"
+    if t == 0xFC:
+        return "RTR (sync)"
+    if t == 0xFD:
+        return "RTR (event)"
+    if t == 0xFE:
+        return "event (mfg)"
+    if t == 0xFF:
+        return "event (profile)"
+    raise ValueError(f"Invalid transmission type 0x{t:X}")
+
+
+def print_map(m: canopen.pdo.base.Map):
+    """Prints out a received PDO.
+
+    Which from this library means a PDO Mapping
+    """
+    data = []
+    for v in m:
+        signed = v.od.data_type in canopen.objectdictionary.SIGNED_TYPES
+        value = int.from_bytes(v.get_data(), byteorder='little', signed=signed)
+        data.append(f"{v.name}: {value}")
+    print(f'{m.cob_id:03X} {m.name} {" ".join(data)}')
+
+
+def listen(bus: str, node_id: int, od: canopen.ObjectDictionary):
+    """Listens for PDOs from the given node, formats and prints them to stdout"""
+    network = canopen.Network()
+    network.connect(channel=bus, bustype='socketcan')
+
+    node = network.add_node(node_id, od)
+    node.tpdo.read(from_od=True)
+    for pdo in node.tpdo.values():
+        pdo.add_callback(print_map)
+    node.tpdo.subscribe()
+
+    try:
+        while True:
+            time.sleep(1)
+            network.check()
+    finally:
+        network.disconnect()
+
+
+def listpdos(node_id: int, od: canopen.ObjectDictionary):
+    """Prints PDO communication and associated mapping parameters for the given node"""
+
+    network = canopen.Network()
+    node = network.add_node(node_id, od)
+    node.tpdo.read(from_od=True)
+    for index, pdo in node.tpdo.items():
+        ttype = transmission_type(pdo.trans_type)
+        names = " | ".join(f"{m.name} {typenames[m.od.data_type]}" for m in pdo)
+        print(f"PDO {index:2} {pdo.cob_id:03X} ({ttype}) => {names}")
+
+
+def pdo_main(args: Namespace | None = None):
+    """The utility for managing PDOs"""
+    if args is None:
+        args = build_parser(ArgumentParser()).parse_args()
+
+    config = OreSatConfig(args.oresat)
+    node_id = config.cards[args.card].node_id
+    od = config.od_db[args.card]
+
+    if args.list:
+        listpdos(node_id, od)
+    else:
+        listen(args.bus, node_id, od)

--- a/oresat_configs/scripts/pdo.py
+++ b/oresat_configs/scripts/pdo.py
@@ -17,14 +17,20 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
     """
     parser.description = PDO
-    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
-                        type=lambda x: x.lower().removeprefix("oresat"),
-                        help="oresat mission, defaults to %(default)s")
+    parser.add_argument(
+        "--oresat",
+        default=Consts.default().arg,
+        choices=[m.arg for m in Consts],
+        type=lambda x: x.lower().removeprefix("oresat"),
+        help="oresat mission, defaults to %(default)s",
+    )
     parser.add_argument("card", help="card name")
-    parser.add_argument("--list", action="store_true",
-                        help="list PDOs expected for the particular card")
-    parser.add_argument("--bus", default="vcan0",
-                        help="CAN bus to listen on, defaults to %(default)s")
+    parser.add_argument(
+        "--list", action="store_true", help="list PDOs expected for the particular card"
+    )
+    parser.add_argument(
+        "--bus", default="vcan0", help="CAN bus to listen on, defaults to %(default)s"
+    )
     return parser
 
 
@@ -43,23 +49,23 @@ def register_subparser(subparsers):
 
 
 typenames = {
-    canopen.objectdictionary.BOOLEAN: 'bool',
-    canopen.objectdictionary.INTEGER8: 'i8',
-    canopen.objectdictionary.INTEGER16: 'i16',
-    canopen.objectdictionary.INTEGER32: 'i32',
-    canopen.objectdictionary.UNSIGNED8: 'u8',
-    canopen.objectdictionary.UNSIGNED16: 'u16',
-    canopen.objectdictionary.UNSIGNED32: 'u32',
-    canopen.objectdictionary.REAL32: 'f32',
-    canopen.objectdictionary.VISIBLE_STRING: 'str',
-    canopen.objectdictionary.OCTET_STRING: 'bytes',
-    canopen.objectdictionary.UNICODE_STRING: 'ustr',
-    canopen.objectdictionary.DOMAIN: 'domain',
+    canopen.objectdictionary.BOOLEAN: "bool",
+    canopen.objectdictionary.INTEGER8: "i8",
+    canopen.objectdictionary.INTEGER16: "i16",
+    canopen.objectdictionary.INTEGER32: "i32",
+    canopen.objectdictionary.UNSIGNED8: "u8",
+    canopen.objectdictionary.UNSIGNED16: "u16",
+    canopen.objectdictionary.UNSIGNED32: "u32",
+    canopen.objectdictionary.REAL32: "f32",
+    canopen.objectdictionary.VISIBLE_STRING: "str",
+    canopen.objectdictionary.OCTET_STRING: "bytes",
+    canopen.objectdictionary.UNICODE_STRING: "ustr",
+    canopen.objectdictionary.DOMAIN: "domain",
     # canopen.objectdictionary.INTEGER24: 'i24',
-    canopen.objectdictionary.REAL64: 'f64',
-    canopen.objectdictionary.INTEGER64: 'i64',
+    canopen.objectdictionary.REAL64: "f64",
+    canopen.objectdictionary.INTEGER64: "i64",
     # canopen.objectdictionary.UNSIGNED24: 'u24',
-    canopen.objectdictionary.UNSIGNED64: 'u64',
+    canopen.objectdictionary.UNSIGNED64: "u64",
 }
 
 
@@ -91,7 +97,7 @@ def print_map(m: canopen.pdo.base.Map):
     data = []
     for v in m:
         signed = v.od.data_type in canopen.objectdictionary.SIGNED_TYPES
-        value = int.from_bytes(v.get_data(), byteorder='little', signed=signed)
+        value = int.from_bytes(v.get_data(), byteorder="little", signed=signed)
         data.append(f"{v.name}: {value}")
     print(f'{m.cob_id:03X} {m.name} {" ".join(data)}')
 
@@ -99,7 +105,7 @@ def print_map(m: canopen.pdo.base.Map):
 def listen(bus: str, node_id: int, od: canopen.ObjectDictionary):
     """Listens for PDOs from the given node, formats and prints them to stdout"""
     network = canopen.Network()
-    network.connect(channel=bus, bustype='socketcan')
+    network.connect(channel=bus, bustype="socketcan")
 
     node = network.add_node(node_id, od)
     node.tpdo.read(from_od=True)

--- a/oresat_configs/scripts/pdo.py
+++ b/oresat_configs/scripts/pdo.py
@@ -1,12 +1,12 @@
 """Tools for working with PDOs"""
 
-from argparse import ArgumentParser, Namespace
 import time
+from argparse import ArgumentParser, Namespace
 from typing import Optional
+
 import canopen
 
-from .. import OreSatConfig, Consts
-
+from .. import Consts, OreSatConfig
 
 PDO = "list or receive PDOs from the specified card"
 

--- a/oresat_configs/scripts/print_od.py
+++ b/oresat_configs/scripts/print_od.py
@@ -1,8 +1,8 @@
 """Print out a card's objects directory."""
 
 import sys
-from argparse import ArgumentParser
-from typing import Any
+from argparse import ArgumentParser, Namespace
+from typing import Any, Optional
 
 import canopen
 
@@ -11,6 +11,31 @@ from .._yaml_to_od import OD_DATA_TYPES
 
 PRINT_OD = "print the object dictionary out to stdout"
 PRINT_OD_PROG = "oresat-print-od"
+
+
+def build_parser(parser: ArgumentParser) -> ArgumentParser:
+    """Configures an ArgumentParser suitable for this script.
+
+    The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
+    """
+    parser.description = PRINT_OD
+    parser.add_argument("oresat", default="oresat0", help="oresat mission; oresat0 or oresat0.5")
+    parser.add_argument("card", help="card name; c3, gps, star_tracker_1, etc")
+    return parser
+
+
+def register_subparser(subparsers):
+    """Registers an ArgumentParser as a subcommand of another parser.
+
+    Intended to be called by __main__.py for each script. Given the output of add_subparsers(),
+    (which I think is a subparser group, but is technically unspecified) this function should
+    create its own ArgumentParser via add_parser(). It must also set_default() the func argument
+    to designate the entry point into this script.
+    See https://docs.python.org/3/library/argparse.html#sub-commands, especially the end of that
+    section, for more.
+    """
+    parser = build_parser(subparsers.add_parser(PRINT_OD_PROG, help=PRINT_OD))
+    parser.set_defaults(func=print_od)
 
 
 def format_default(value: Any) -> str:
@@ -22,16 +47,10 @@ def format_default(value: Any) -> str:
     return value
 
 
-def print_od(sys_args=None):
+def print_od(args: Optional[Namespace] = None):
     """The print-od main"""
-
-    if sys_args is None:
-        sys_args = sys.argv[1:]
-
-    parser = ArgumentParser(description=PRINT_OD, prog=PRINT_OD_PROG)
-    parser.add_argument("oresat", default="oresat0", help="oresat mission; oresat0 or oresat0.5")
-    parser.add_argument("card", help="card name; c3, gps, star_tracker_1, etc")
-    args = parser.parse_args(sys_args)
+    if args is None:
+        args = build_parser(ArgumentParser()).parse_args()
 
     arg_oresat = args.oresat.lower()
     if arg_oresat in ["0", "oresat0"]:

--- a/oresat_configs/scripts/print_od.py
+++ b/oresat_configs/scripts/print_od.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 import canopen
 
-from .. import OreSatConfig, Consts
+from .. import Consts, OreSatConfig
 from .._yaml_to_od import OD_DATA_TYPES
 
 PRINT_OD = "print the object dictionary out to stdout"

--- a/oresat_configs/scripts/print_od.py
+++ b/oresat_configs/scripts/print_od.py
@@ -9,7 +9,6 @@ from .. import OreSatConfig, Consts
 from .._yaml_to_od import OD_DATA_TYPES
 
 PRINT_OD = "print the object dictionary out to stdout"
-PRINT_OD_PROG = "oresat-print-od"
 
 
 def build_parser(parser: ArgumentParser) -> ArgumentParser:
@@ -35,7 +34,7 @@ def register_subparser(subparsers):
     See https://docs.python.org/3/library/argparse.html#sub-commands, especially the end of that
     section, for more.
     """
-    parser = build_parser(subparsers.add_parser(PRINT_OD_PROG, help=PRINT_OD))
+    parser = build_parser(subparsers.add_parser("od", help=PRINT_OD))
     parser.set_defaults(func=print_od)
 
 

--- a/oresat_configs/scripts/print_od.py
+++ b/oresat_configs/scripts/print_od.py
@@ -17,9 +17,13 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
     """
     parser.description = PRINT_OD
-    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
-                        type=lambda x: x.lower().removeprefix("oresat"),
-                        help="oresat mission, defaults to %(default)s")
+    parser.add_argument(
+        "--oresat",
+        default=Consts.default().arg,
+        choices=[m.arg for m in Consts],
+        type=lambda x: x.lower().removeprefix("oresat"),
+        help="oresat mission, defaults to %(default)s",
+    )
     parser.add_argument("card", help="card name; c3, gps, star_tracker_1, etc")
     return parser
 

--- a/oresat_configs/scripts/print_od.py
+++ b/oresat_configs/scripts/print_od.py
@@ -1,12 +1,11 @@
 """Print out a card's objects directory."""
 
-import sys
 from argparse import ArgumentParser, Namespace
 from typing import Any, Optional
 
 import canopen
 
-from .. import OreSatConfig, OreSatId
+from .. import OreSatConfig, Consts
 from .._yaml_to_od import OD_DATA_TYPES
 
 PRINT_OD = "print the object dictionary out to stdout"
@@ -19,7 +18,9 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
     """
     parser.description = PRINT_OD
-    parser.add_argument("oresat", default="oresat0", help="oresat mission; oresat0 or oresat0.5")
+    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
+                        type=lambda x: x.lower().removeprefix("oresat"),
+                        help="oresat mission, defaults to %(default)s")
     parser.add_argument("card", help="card name; c3, gps, star_tracker_1, etc")
     return parser
 
@@ -52,18 +53,7 @@ def print_od(args: Optional[Namespace] = None):
     if args is None:
         args = build_parser(ArgumentParser()).parse_args()
 
-    arg_oresat = args.oresat.lower()
-    if arg_oresat in ["0", "oresat0"]:
-        oresat_id = OreSatId.ORESAT0
-    elif arg_oresat in ["0.5", "oresat0.5"]:
-        oresat_id = OreSatId.ORESAT0_5
-    elif arg_oresat in ["1", "oresat1"]:
-        oresat_id = OreSatId.ORESAT1
-    else:
-        print(f"invalid oresat mission: {args.oresat}")
-        sys.exit()
-
-    config = OreSatConfig(oresat_id)
+    config = OreSatConfig(args.oresat)
 
     inverted_od_data_types = {}
     for key, value in OD_DATA_TYPES.items():

--- a/oresat_configs/scripts/sdo_transfer.py
+++ b/oresat_configs/scripts/sdo_transfer.py
@@ -8,7 +8,7 @@ node's Object Dictionaries.
 import os
 import sys
 from argparse import ArgumentParser, Namespace
-from typing import Optional
+from typing import Optional, Union
 
 import canopen
 
@@ -97,6 +97,10 @@ def sdo_transfer(args: Optional[Namespace] = None):
 
     # send SDO
     try:
+        # Type definiton to satisfy mypy, matches canopen.Variable.raw and .phys type
+        # While canopen does declare types, it's not fully set up to have outside
+        # projects use them?
+        value: Union[int, bool, float, str, bytes]
         if args.mode in ["r", "read"]:
             if obj.data_type == binary_type:
                 with open(args.value[5:], "wb") as f:

--- a/oresat_configs/scripts/sdo_transfer.py
+++ b/oresat_configs/scripts/sdo_transfer.py
@@ -12,7 +12,7 @@ from typing import Optional, Union
 
 import canopen
 
-from .. import OreSatConfig, Consts
+from .. import Consts, OreSatConfig
 
 SDO_TRANSFER = "read or write value to a node's object dictionary via SDO transfers"
 

--- a/oresat_configs/scripts/sdo_transfer.py
+++ b/oresat_configs/scripts/sdo_transfer.py
@@ -36,9 +36,13 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
         help="data to write or for only octet/domain data types a path to a file "
         "(e.g. file:data.bin)",
     )
-    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
-                        type=lambda x: x.lower().removeprefix("oresat"),
-                        help="oresat mission, defaults to %(default)s")
+    parser.add_argument(
+        "--oresat",
+        default=Consts.default().arg,
+        choices=[m.arg for m in Consts],
+        type=lambda x: x.lower().removeprefix("oresat"),
+        help="oresat mission, defaults to %(default)s",
+    )
     return parser
 
 

--- a/oresat_configs/scripts/sdo_transfer.py
+++ b/oresat_configs/scripts/sdo_transfer.py
@@ -7,7 +7,8 @@ node's Object Dictionaries.
 
 import os
 import sys
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
+from typing import Optional
 
 import canopen
 
@@ -17,13 +18,12 @@ SDO_TRANSFER = "read or write value to a node's object dictionary via SDO transf
 SDO_TRANSFER_PROG = "oresat-sdo-transfer"
 
 
-def sdo_transfer(sys_args=None):
-    """Read or write data to a node using a SDO."""
+def build_parser(parser: ArgumentParser) -> ArgumentParser:
+    """Configures an ArgumentParser suitable for this script.
 
-    if sys_args is None:
-        sys_args = sys.argv[1:]
-
-    parser = ArgumentParser(description=SDO_TRANSFER, prog=SDO_TRANSFER_PROG)
+    The given parser may be standalone or it may be used as a subcommand in another ArgumentParser.
+    """
+    parser.description = SDO_TRANSFER
     parser.add_argument("bus", metavar="BUS", help="CAN bus to use (e.g., can0, vcan0)")
     parser.add_argument("node", metavar="NODE", help="device node name (e.g. gps, solar_module_1)")
     parser.add_argument("mode", metavar="MODE", help="r[ead] or w[rite] (e.g. r, read, w, write)")
@@ -44,7 +44,27 @@ def sdo_transfer(sys_args=None):
         default="oresat0.5",
         help="oresat# (e.g.: oresat0, oresat0.5, oresat1)",
     )
-    args = parser.parse_args(sys_args)
+    return parser
+
+
+def register_subparser(subparsers):
+    """Registers an ArgumentParser as a subcommand of another parser.
+
+    Intended to be called by __main__.py for each script. Given the output of add_subparsers(),
+    (which I think is a subparser group, but is technically unspecified) this function should
+    create its own ArgumentParser via add_parser(). It must also set_default() the func argument
+    to designate the entry point into this script.
+    See https://docs.python.org/3/library/argparse.html#sub-commands, especially the end of that
+    section, for more.
+    """
+    parser = build_parser(subparsers.add_parser(SDO_TRANSFER_PROG, help=SDO_TRANSFER))
+    parser.set_defaults(func=sdo_transfer)
+
+
+def sdo_transfer(args: Optional[Namespace] = None):
+    """Read or write data to a node using a SDO."""
+    if args is None:
+        args = build_parser(ArgumentParser()).parse_args()
 
     arg_oresat = args.oresat.lower()
     if arg_oresat in ["0", "oresat0"]:

--- a/oresat_configs/scripts/sdo_transfer.py
+++ b/oresat_configs/scripts/sdo_transfer.py
@@ -15,7 +15,6 @@ import canopen
 from .. import OreSatConfig, Consts
 
 SDO_TRANSFER = "read or write value to a node's object dictionary via SDO transfers"
-SDO_TRANSFER_PROG = "oresat-sdo-transfer"
 
 
 def build_parser(parser: ArgumentParser) -> ArgumentParser:
@@ -53,7 +52,7 @@ def register_subparser(subparsers):
     See https://docs.python.org/3/library/argparse.html#sub-commands, especially the end of that
     section, for more.
     """
-    parser = build_parser(subparsers.add_parser(SDO_TRANSFER_PROG, help=SDO_TRANSFER))
+    parser = build_parser(subparsers.add_parser("sdo", help=SDO_TRANSFER))
     parser.set_defaults(func=sdo_transfer)
 
 

--- a/oresat_configs/scripts/sdo_transfer.py
+++ b/oresat_configs/scripts/sdo_transfer.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 import canopen
 
-from .. import OreSatConfig, OreSatId
+from .. import OreSatConfig, Consts
 
 SDO_TRANSFER = "read or write value to a node's object dictionary via SDO transfers"
 SDO_TRANSFER_PROG = "oresat-sdo-transfer"
@@ -37,13 +37,9 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
         help="data to write or for only octet/domain data types a path to a file "
         "(e.g. file:data.bin)",
     )
-    parser.add_argument(
-        "-o",
-        "--oresat",
-        metavar="ORESAT",
-        default="oresat0.5",
-        help="oresat# (e.g.: oresat0, oresat0.5, oresat1)",
-    )
+    parser.add_argument("--oresat", default=Consts.default().arg, choices=[m.arg for m in Consts],
+                        type=lambda x: x.lower().removeprefix("oresat"),
+                        help="oresat mission, defaults to %(default)s")
     return parser
 
 
@@ -66,18 +62,7 @@ def sdo_transfer(args: Optional[Namespace] = None):
     if args is None:
         args = build_parser(ArgumentParser()).parse_args()
 
-    arg_oresat = args.oresat.lower()
-    if arg_oresat in ["0", "oresat0"]:
-        oresat_id = OreSatId.ORESAT0
-    elif arg_oresat in ["0.5", "oresat0.5"]:
-        oresat_id = OreSatId.ORESAT0_5
-    elif arg_oresat in ["1", "oresat1"]:
-        oresat_id = OreSatId.ORESAT1
-    else:
-        print(f"invalid oresat mission: {args.oresat}")
-        sys.exit()
-
-    config = OreSatConfig(oresat_id)
+    config = OreSatConfig(args.oresat)
 
     if args.value.startswith("file:"):
         if not os.path.isfile(args.value[5:]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,8 @@ linters = "pycodestyle,pyflakes,pylint,mccabe,mypy,radon"
 # R1702:    Too many nested blocks
 # E0401:    Cannot find implementation or library stub for module named
 # R0902:    Too many instance attributes
-ignore = "E402,C901,C0103,E203,R0912,R0915,R901,R901,R0914,C0413,C0206,R1716,W1514,R1702,E0401,R0902"
+# W0511:    TODOs or FIXMEs
+ignore = "E402,C901,C0103,E203,R0912,R0915,R901,R901,R0914,C0413,C0206,R1716,W1514,R1702,E0401,R0902,W0511"
 max_line_length = 100
 
 [[tool.pylama.files]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,6 @@ pyyaml
 setuptools
 sphinx
 sphinx-rtd-theme
+tabulate
+types-tabulate
 wheel

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ import unittest
 
 import canopen
 
-from oresat_configs import OreSatConfig, OreSatId
+from oresat_configs import OreSatConfig, Consts
 from oresat_configs._yaml_to_od import OD_DATA_TYPE_SIZE, TPDO_COMM_START, TPDO_PARA_START
 
 
@@ -13,7 +13,7 @@ class TestConfig(unittest.TestCase):
     """Base class to test a OreSat OD databases."""
 
     def setUp(self):
-        self.id = OreSatId.ORESAT0
+        self.id = Consts.ORESAT0
         self.config = OreSatConfig(self.id)
 
     def test_tpdo_sizes(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ import unittest
 
 import canopen
 
-from oresat_configs import OreSatConfig, Consts
+from oresat_configs import Consts, OreSatConfig
 from oresat_configs._yaml_to_od import OD_DATA_TYPE_SIZE, TPDO_COMM_START, TPDO_PARA_START
 
 

--- a/tests/test_oresat0.py
+++ b/tests/test_oresat0.py
@@ -1,6 +1,6 @@
 """Unit tests for OreSat0 OD database."""
 
-from oresat_configs import OreSatConfig, OreSatId
+from oresat_configs import OreSatConfig, Consts
 
 from . import TestConfig
 
@@ -9,5 +9,5 @@ class TestOreSat0(TestConfig):
     """Test the OreSat0 OD database."""
 
     def setUp(self):
-        self.id = OreSatId.ORESAT0
+        self.id = Consts.ORESAT0
         self.config = OreSatConfig(self.id)

--- a/tests/test_oresat0.py
+++ b/tests/test_oresat0.py
@@ -1,6 +1,6 @@
 """Unit tests for OreSat0 OD database."""
 
-from oresat_configs import OreSatConfig, Consts
+from oresat_configs import Consts, OreSatConfig
 
 from . import TestConfig
 

--- a/tests/test_oresat0_5.py
+++ b/tests/test_oresat0_5.py
@@ -1,6 +1,6 @@
 """Unit tests for OreSat0.5 OD database."""
 
-from oresat_configs import OreSatConfig, OreSatId
+from oresat_configs import OreSatConfig, Consts
 
 from . import TestConfig
 
@@ -9,5 +9,5 @@ class TestOreSat0_5(TestConfig):
     """Test the OreSat0.5 OD database"""
 
     def setUp(self):
-        self.id = OreSatId.ORESAT0_5
+        self.id = Consts.ORESAT0_5
         self.config = OreSatConfig(self.id)

--- a/tests/test_oresat0_5.py
+++ b/tests/test_oresat0_5.py
@@ -1,6 +1,6 @@
 """Unit tests for OreSat0.5 OD database."""
 
-from oresat_configs import OreSatConfig, Consts
+from oresat_configs import Consts, OreSatConfig
 
 from . import TestConfig
 


### PR DESCRIPTION
This adds
 - The `pdo` script, which can list or listen for TPDOs from specified cards
 - The `cards` script, which lists available cards for a given Oresat mission
 - Improvements to the top level `oresat_configs` script dispatcher and some options to make discovery easier
