### PR TITLE
use setuptools-scm for package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,12 @@ OD.*
 
 # Beacon def formats
 *xtce.xml
+
+# MacOS
+.DS_Store
+
+# Vim
+*.swp
+
+# setuptools-scm
+*/_version.py

--- a/oresat_configs/constants.py
+++ b/oresat_configs/constants.py
@@ -6,7 +6,17 @@ Seperate from __init__.py to avoid cirular imports.
 
 from enum import IntEnum
 
-__version__ = "0.3.1"
+__all__ = [
+    "__version__",
+    "OreSatId",
+    "ORESAT_NICE_NAMES",
+    "NodeId",
+]
+
+try:
+    from ._version import version as __version__  # type: ignore
+except ImportError:
+    __version__ = "0.0.0"  # package is not installed
 
 
 class OreSatId(IntEnum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -33,14 +33,14 @@ oresat-print-od = "oresat_configs.scripts.print_od:print_od"
 oresat-sdo-transfer = "oresat_configs.scripts.sdo_transfer:sdo_transfer"
 oresat-gen-xtce = "oresat_configs.scripts.gen_xtce:gen_xtce"
 
-[tool.setuptools.dynamic]
-version = {attr = "oresat_configs.constants.__version__"}
-
 [tool.setuptools.packages.find]
-exclude = ["docs*", "tests*"] 
+exclude = ["docs*", "tests*"]
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml", "*.csv"]
+
+[tool.setuptools_scm]
+write_to = "oresat_configs/_version.py"
 
 [tool.black]
 line_length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pylama[all]
 pylama[toml]
 pyyaml
 setuptools
+setuptools-scm
 sphinx
 sphinx-rtd-theme
 wheel


### PR DESCRIPTION
This change will generate the package version based off of git tags and git comments. This will help identify which cards on FlatSat are using a unreleased version of `oresat-config` during integration / testing.

If the package is built of a tagged commit the version will match the tagged version, if the package is built of a non-tagged commit it will include the last tagged version, start of the commit hash, and the date; e.g.: `0.3.2.dev9+g9afbd58.d20240224`.

Also, we don't have to worry about updating `__version__` when tagging a commit.