### PR TITLE
Yaml dataclass tests

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,12 +27,12 @@ release = __version__
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions: list = [
+extensions: list[str] = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
 ]
-templates_path: list = []
-exclude_patterns: list = []
+templates_path: list[str] = []
+exclude_patterns: list[str] = []
 add_module_names = False
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/scripts/gen_beacon_rst.py
+++ b/docs/scripts/gen_beacon_rst.py
@@ -31,7 +31,7 @@ OD_DATA_TYPES = {
 """Nice names for CANopen data types."""
 
 
-def gen_beacon_rst(config: OreSatConfig, file_path: str, url: str):
+def gen_beacon_rst(config: OreSatConfig, file_path: str, url: str) -> None:
     """Genetate a rst file for a beacon definition."""
 
     title = "Beacon Definition"
@@ -202,7 +202,7 @@ def gen_beacon_rst(config: OreSatConfig, file_path: str, url: str):
         f.writelines(lines)
 
 
-def gen_beacon_rst_files():
+def gen_beacon_rst_files() -> None:
     """Generate all beacon rst files."""
 
     parent_dir = os.path.dirname(os.path.abspath(__file__ + "/.."))

--- a/oresat_configs/__init__.py
+++ b/oresat_configs/__init__.py
@@ -1,11 +1,7 @@
 """OreSat OD database"""
 
-import csv
-import os
 from dataclasses import dataclass
 from typing import Union
-
-from dataclasses_json import dataclass_json
 
 from ._yaml_to_od import (
     _gen_c3_beacon_defs,
@@ -16,45 +12,10 @@ from ._yaml_to_od import (
 )
 from .base import FW_COMMON_CONFIG_PATH
 from .beacon_config import BeaconConfig
+from .card_info import Card, cards_from_csv
 from .constants import Consts, NodeId, OreSatId, __version__
 
-
-@dataclass_json
-@dataclass
-class Card:
-    """Card info."""
-
-    nice_name: str
-    """A nice name for the card."""
-    node_id: int
-    """CANopen node id."""
-    processor: str
-    """Processor type; e.g.: "octavo", "stm32", or "none"."""
-    opd_address: int
-    """OPD address."""
-    opd_always_on: bool
-    """Keep the card on all the time. Only for battery cards."""
-    child: str = ""
-    """Optional child node name. Useful for CFC cards."""
-
-
-def cards_from_csv(oresat: Consts) -> dict[str, Card]:
-    """Turns cards.csv into a dict of names->Cards, filtered by the current mission"""
-
-    file_path = f"{os.path.dirname(os.path.abspath(__file__))}/cards.csv"
-    with open(file_path, "r") as f:
-        return {
-            row["name"]: Card(
-                row["nice_name"],
-                int(row["node_id"], 16),
-                row["processor"],
-                int(row["opd_address"], 16),
-                row["opd_always_on"].lower() == "true",
-                row["child"],
-            )
-            for row in csv.DictReader(f)
-            if row["name"] in oresat.cards_path
-        }
+__all__ = ["Card", "Consts", "NodeId", "OreSatId", "__version__"]
 
 
 class OreSatConfig:

--- a/oresat_configs/__main__.py
+++ b/oresat_configs/__main__.py
@@ -32,7 +32,7 @@ SCRIPTS = [
 ]
 
 
-def oresat_configs():
+def oresat_configs() -> None:
     """oresat_configs main."""
     parser = argparse.ArgumentParser(prog="oresat_configs")
     parser.add_argument("--version", action="version", version="%(prog)s v" + __version__)

--- a/oresat_configs/_yaml_to_od.py
+++ b/oresat_configs/_yaml_to_od.py
@@ -2,18 +2,23 @@
 
 import os
 from copy import deepcopy
-from typing import Dict
+from typing import Any, Union
 
 import canopen
+from canopen import ObjectDictionary
+from canopen.objectdictionary import Array, Record, Variable
 from yaml import load
 
+Loader: Any
 try:
     from yaml import CLoader as Loader
 except ImportError:
     from yaml import Loader
 
+from .base import ConfigPaths
 from .beacon_config import BeaconConfig
-from .card_config import CardConfig, IndexObject
+from .card_config import CardConfig, ConfigObject, IndexObject, SubindexObject
+from .card_info import Card
 from .constants import Consts, __version__
 
 STD_OBJS_FILE_NAME = f"{os.path.dirname(os.path.abspath(__file__))}/standard_objects.yaml"
@@ -81,7 +86,7 @@ DYNAMIC_LEN_DATA_TYPES = [
 ]
 
 
-def _set_var_default(obj, var: canopen.objectdictionary.Variable):
+def _set_var_default(obj: ConfigObject, var: Variable) -> None:
     """Set the variables default value based off of configs."""
 
     default = obj.default
@@ -104,7 +109,7 @@ def _set_var_default(obj, var: canopen.objectdictionary.Variable):
     var.default = default
 
 
-def _make_var(obj, index: int, subindex: int = 0) -> canopen.objectdictionary.Variable:
+def _make_var(obj: Union[IndexObject, SubindexObject], index: int, subindex: int = 0) -> Variable:
     var = canopen.objectdictionary.Variable(obj.name, index, subindex)
     var.access_type = obj.access_type
     var.description = obj.description
@@ -124,7 +129,7 @@ def _make_var(obj, index: int, subindex: int = 0) -> canopen.objectdictionary.Va
     return var
 
 
-def _make_rec(obj) -> canopen.objectdictionary.Record:
+def _make_rec(obj: IndexObject) -> Record:
     index = obj.index
     rec = canopen.objectdictionary.Record(obj.name, index)
 
@@ -145,7 +150,7 @@ def _make_rec(obj) -> canopen.objectdictionary.Record:
     return rec
 
 
-def _make_arr(obj, node_ids: dict) -> canopen.objectdictionary.Array:
+def _make_arr(obj: IndexObject, node_ids: dict[str, int]) -> Array:
     index = obj.index
     arr = canopen.objectdictionary.Array(obj.name, index)
 
@@ -157,8 +162,11 @@ def _make_arr(obj, node_ids: dict) -> canopen.objectdictionary.Array:
     subindexes = []
     names = []
     generate_subindexes = obj.generate_subindexes
+    if generate_subindexes is None:
+        raise ValueError("IndexObject for array missing generate_subindexes: {obj}")
+
     if generate_subindexes.subindexes == "fixed_length":
-        subindexes = list(range(1, obj.generate_subindexes.length + 1))
+        subindexes = list(range(1, generate_subindexes.length + 1))
         names = [obj.name + f"_{subindex}" for subindex in subindexes]
     elif generate_subindexes.subindexes == "node_ids":
         for name, sub in node_ids.items():
@@ -188,7 +196,9 @@ def _make_arr(obj, node_ids: dict) -> canopen.objectdictionary.Array:
     return arr
 
 
-def _add_objects(od: canopen.ObjectDictionary, objects: list, node_ids: dict):
+def _add_objects(
+    od: ObjectDictionary, objects: list[IndexObject], node_ids: dict[str, int]
+) -> None:
     """File a objectdictionary with all the objects."""
 
     for obj in objects:
@@ -206,7 +216,7 @@ def _add_objects(od: canopen.ObjectDictionary, objects: list, node_ids: dict):
             od.add_object(arr)
 
 
-def _add_tpdo_data(od: canopen.ObjectDictionary, config: CardConfig):
+def _add_tpdo_data(od: ObjectDictionary, config: CardConfig) -> None:
     """Add tpdo objects to OD."""
 
     tpdos = config.tpdos
@@ -301,10 +311,10 @@ def _add_tpdo_data(od: canopen.ObjectDictionary, config: CardConfig):
 
 def _add_rpdo_data(
     tpdo_num: int,
-    rpdo_node_od: canopen.ObjectDictionary,
-    tpdo_node_od: canopen.ObjectDictionary,
+    rpdo_node_od: ObjectDictionary,
+    tpdo_node_od: ObjectDictionary,
     tpdo_node_name: str,
-):
+) -> None:
     tpdo_comm_index = TPDO_COMM_START + tpdo_num - 1
     tpdo_mapping_index = TPDO_PARA_START + tpdo_num - 1
 
@@ -432,7 +442,9 @@ def _add_rpdo_data(
         rpdo_mapping_rec[0].default += 1
 
 
-def _add_node_rpdo_data(config, od: canopen.ObjectDictionary, od_db: dict):
+def _add_node_rpdo_data(
+    config: CardConfig, od: ObjectDictionary, od_db: dict[str, ObjectDictionary]
+) -> None:
     """Add all configured RPDO object to OD based off of TPDO objects from another OD."""
 
     for rpdo in config.rpdos:
@@ -440,10 +452,10 @@ def _add_node_rpdo_data(config, od: canopen.ObjectDictionary, od_db: dict):
 
 
 def _add_all_rpdo_data(
-    master_node_od: canopen.ObjectDictionary,
-    node_od: canopen.ObjectDictionary,
+    master_node_od: ObjectDictionary,
+    node_od: ObjectDictionary,
     node_name: str,
-):
+) -> None:
     """Add all RPDO object to OD based off of TPDO objects from another OD."""
 
     if not node_od.device_information.nr_of_TXPDO:
@@ -456,7 +468,9 @@ def _add_all_rpdo_data(
         _add_rpdo_data(i, master_node_od, node_od, node_name)
 
 
-def _load_std_objs(file_path: str, node_ids: dict) -> dict:
+def _load_std_objs(
+    file_path: str, node_ids: dict[str, int]
+) -> dict[str, Union[Variable, Record, Array]]:
     """Load the standard objects."""
 
     with open(file_path, "r") as f:
@@ -474,7 +488,7 @@ def _load_std_objs(file_path: str, node_ids: dict) -> dict:
     return std_objs
 
 
-def overlay_configs(card_config, overlay_config):
+def overlay_configs(card_config: CardConfig, overlay_config: CardConfig) -> None:
     """deal with overlays"""
 
     # overlay object
@@ -533,10 +547,10 @@ def overlay_configs(card_config, overlay_config):
             card_config.rpdos.append(deepcopy(overlay_rpdo))
 
 
-def _load_configs(config_paths: dict) -> Dict[str, CardConfig]:
+def _load_configs(config_paths: ConfigPaths) -> dict[str, CardConfig]:
     """Generate all ODs for a OreSat mission."""
 
-    configs: Dict[str, CardConfig] = {}
+    configs: dict[str, CardConfig] = {}
 
     for name, paths in config_paths.items():
         if paths is None:
@@ -564,7 +578,9 @@ def _load_configs(config_paths: dict) -> Dict[str, CardConfig]:
     return configs
 
 
-def _gen_od_db(oresat: Consts, cards: dict, beacon_def: BeaconConfig, configs: dict) -> dict:
+def _gen_od_db(
+    oresat: Consts, cards: dict[str, Card], beacon_def: BeaconConfig, configs: dict[str, CardConfig]
+) -> dict[str, ObjectDictionary]:
     od_db = {}
     node_ids = {name: cards[name].node_id for name in configs}
     node_ids["c3"] = 0x1
@@ -642,7 +658,7 @@ def _gen_od_db(oresat: Consts, cards: dict, beacon_def: BeaconConfig, configs: d
     return od_db
 
 
-def _gen_c3_fram_defs(c3_od: canopen.ObjectDictionary, config: CardConfig) -> list:
+def _gen_c3_fram_defs(c3_od: ObjectDictionary, config: CardConfig) -> list[Variable]:
     """Get the list of objects in saved to fram."""
 
     fram_objs = []
@@ -657,7 +673,7 @@ def _gen_c3_fram_defs(c3_od: canopen.ObjectDictionary, config: CardConfig) -> li
     return fram_objs
 
 
-def _gen_c3_beacon_defs(c3_od: canopen.ObjectDictionary, beacon_def: BeaconConfig) -> list:
+def _gen_c3_beacon_defs(c3_od: ObjectDictionary, beacon_def: BeaconConfig) -> list[Variable]:
     """Get the list of objects in the beacon from OD."""
 
     beacon_objs = []

--- a/oresat_configs/base/__init__.py
+++ b/oresat_configs/base/__init__.py
@@ -1,6 +1,9 @@
 """OreSat od base configs."""
 
 import os
+from typing import Optional
+
+ConfigPaths = dict[str, Optional[tuple[str, ...]]]
 
 _CONFIGS_DIR = os.path.dirname(os.path.abspath(__file__))
 FW_COMMON_CONFIG_PATH = f"{_CONFIGS_DIR}/fw_common.yaml"

--- a/oresat_configs/base/c3.yaml
+++ b/oresat_configs/base/c3.yaml
@@ -576,9 +576,9 @@ objects:
       data_type: uint8
       access_type: ro
       value_descriptions:
-        off: 0
+        'off': 0
         boot: 1
-        on: 2
+        'on': 2
         error: 3
         not_found: 4
         dead: 0xff

--- a/oresat_configs/base/cfc.yaml
+++ b/oresat_configs/base/cfc.yaml
@@ -7,7 +7,7 @@ objects:
         name: status
         data_type: uint8
         value_descriptions:
-          off: 1
+          'off': 1
           standby: 2
           capture: 3
           error: 4

--- a/oresat_configs/base/dxwifi.yaml
+++ b/oresat_configs/base/dxwifi.yaml
@@ -5,7 +5,7 @@ objects:
     description: the dxwifi status
     access_type: rw
     value_descriptions:
-      off: 0
+      'off': 0
       boot: 1
       standby: 2
       film: 3

--- a/oresat_configs/base/gps.yaml
+++ b/oresat_configs/base/gps.yaml
@@ -3,7 +3,7 @@ objects:
     name: status
     data_type: uint8
     value_descriptions:
-      off: 0
+      'off': 0
       searching: 1
       locked: 2
       error: 3

--- a/oresat_configs/base/star_tracker.yaml
+++ b/oresat_configs/base/star_tracker.yaml
@@ -3,7 +3,7 @@ objects:
     name: status
     data_type: uint8
     value_descriptions:
-      off: 0
+      'off': 0
       boot: 1
       standby: 2
       low_power: 3

--- a/oresat_configs/beacon_config.py
+++ b/oresat_configs/beacon_config.py
@@ -1,14 +1,18 @@
 """Load a beacon config file."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import List
+from typing import Any
 
 from yaml import load
 
+Loader: Any
 try:
     from yaml import CLoader as Loader
 except ImportError:
     from yaml import Loader
+
 from dataclasses_json import dataclass_json
 
 
@@ -79,14 +83,14 @@ class BeaconConfig:
     """Beacon revision number."""
     ax25: BeaconAx25Config
     """AX.25 configs section."""
-    fields: List[List[str]] = field(default_factory=list)
+    fields: list[list[str]] = field(default_factory=list)
     """
     List of index and subindexes of objects from the C3's object dictionary to be added to the
     beacon.
     """
 
     @classmethod
-    def from_yaml(cls, config_path: str):
+    def from_yaml(cls, config_path: str) -> BeaconConfig:
         """Load a beacon YAML config file."""
 
         with open(config_path, "r") as f:

--- a/oresat_configs/card_config.py
+++ b/oresat_configs/card_config.py
@@ -1,14 +1,18 @@
 """Load a card config file."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from yaml import load
 
+Loader: Any
 try:
     from yaml import CLoader as Loader
 except ImportError:
     from yaml import Loader
+
 from dataclasses_json import dataclass_json
 
 
@@ -29,9 +33,9 @@ class ConfigObject:
     """Default value of object."""
     description: str = ""
     """Description of object."""
-    value_descriptions: Dict[str, int] = field(default_factory=dict)
+    value_descriptions: dict[str, int] = field(default_factory=dict)
     """Optional: Can be used to define enum values for an unsigned integer data types."""
-    bit_definitions: Dict[str, Union[int, str]] = field(default_factory=dict)
+    bit_definitions: dict[str, Union[int, str]] = field(default_factory=dict)
     """Optional: Can be used to define bitfield of an unsigned integer data types."""
     unit: str = ""
     """Optional unit for the object."""
@@ -127,7 +131,7 @@ class IndexObject(ConfigObject):
     """Index of object, fw/sw common object are in 0x3000, card objects are in 0x4000."""
     object_type: str = "variable"
     """Object type; must be ``"variable"``, ``"array"``, or ``"record"``."""
-    subindexes: List[SubindexObject] = field(default_factory=list)
+    subindexes: list[SubindexObject] = field(default_factory=list)
     """Defines subindexes for records and arrays."""
     generate_subindexes: Optional[GenerateSubindex] = None
     """Used to generate subindexes for arrays."""
@@ -168,7 +172,7 @@ class Tpdo:
     """Send the TPDO periodicly in milliseconds."""
     inhibit_time_ms: int = 0
     """Delay after boot before the event timer starts in milliseconds."""
-    fields: List[List[str]] = field(default_factory=list)
+    fields: list[list[str]] = field(default_factory=list)
     """Index and subindexes of objects to map to the TPDO."""
 
 
@@ -229,19 +233,19 @@ class CardConfig:
           ...
     """
 
-    std_objects: List[str] = field(default_factory=list)
+    std_objects: list[str] = field(default_factory=list)
     """Standard object to include in OD."""
-    objects: List[IndexObject] = field(default_factory=list)
+    objects: list[IndexObject] = field(default_factory=list)
     """Unique card objects."""
-    tpdos: List[Tpdo] = field(default_factory=list)
+    tpdos: list[Tpdo] = field(default_factory=list)
     """TPDOs for the card."""
-    rpdos: List[Rpdo] = field(default_factory=list)
+    rpdos: list[Rpdo] = field(default_factory=list)
     """RPDOs for the card."""
-    fram: List[List[str]] = field(default_factory=list)
+    fram: list[list[str]] = field(default_factory=list)
     """C3 only. List of index and subindex for the c3 to save the values of to F-RAM."""
 
     @classmethod
-    def from_yaml(cls, config_path: str):
+    def from_yaml(cls, config_path: str) -> CardConfig:
         """Load a card YAML config file."""
 
         with open(config_path, "r") as f:

--- a/oresat_configs/card_config.py
+++ b/oresat_configs/card_config.py
@@ -31,7 +31,7 @@ class ConfigObject:
     """Description of object."""
     value_descriptions: Dict[str, int] = field(default_factory=dict)
     """Optional: Can be used to define enum values for an unsigned integer data types."""
-    bit_definitions: Dict[str, int] = field(default_factory=dict)
+    bit_definitions: Dict[str, Union[int, str]] = field(default_factory=dict)
     """Optional: Can be used to define bitfield of an unsigned integer data types."""
     unit: str = ""
     """Optional unit for the object."""

--- a/oresat_configs/card_info.py
+++ b/oresat_configs/card_info.py
@@ -1,0 +1,47 @@
+"""Utilities for top level cards definitions, not in the OD"""
+
+import csv
+import os
+from dataclasses import dataclass
+
+from dataclasses_json import dataclass_json
+
+from .constants import Consts
+
+
+@dataclass_json
+@dataclass
+class Card:
+    """Card info."""
+
+    nice_name: str
+    """A nice name for the card."""
+    node_id: int
+    """CANopen node id."""
+    processor: str
+    """Processor type; e.g.: "octavo", "stm32", or "none"."""
+    opd_address: int
+    """OPD address."""
+    opd_always_on: bool
+    """Keep the card on all the time. Only for battery cards."""
+    child: str = ""
+    """Optional child node name. Useful for CFC cards."""
+
+
+def cards_from_csv(oresat: Consts) -> dict[str, Card]:
+    """Turns cards.csv into a dict of names->Cards, filtered by the current mission"""
+
+    file_path = f"{os.path.dirname(os.path.abspath(__file__))}/cards.csv"
+    with open(file_path, "r") as f:
+        return {
+            row["name"]: Card(
+                row["nice_name"],
+                int(row["node_id"], 16),
+                row["processor"],
+                int(row["opd_address"], 16),
+                row["opd_always_on"].lower() == "true",
+                row["child"],
+            )
+            for row in csv.DictReader(f)
+            if row["name"] in oresat.cards_path
+        }

--- a/oresat_configs/constants.py
+++ b/oresat_configs/constants.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from enum import Enum, IntEnum, unique
 
 from . import oresat0, oresat0_5, oresat1
+from .base import ConfigPaths
 
 __version__ = "0.3.1"
 
@@ -21,7 +22,7 @@ class Mission:
     id: int
     arg: str
     beacon_path: str
-    cards_path: dict[str, tuple[str, ...] | None]
+    cards_path: ConfigPaths
 
 
 @unique

--- a/oresat_configs/oresat0/__init__.py
+++ b/oresat_configs/oresat0/__init__.py
@@ -1,7 +1,6 @@
 """OreSat0 object dictionary and beacon constants."""
 
 import os
-from typing import Optional
 
 from ..base import (
     BAT_CONFIG_PATH,
@@ -13,6 +12,7 @@ from ..base import (
     SOLAR_CONFIG_PATH,
     ST_CONFIG_PATH,
     SW_COMMON_CONFIG_PATH,
+    ConfigPaths,
 )
 
 _CONFIGS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -21,7 +21,7 @@ BAT_OVERLAY_CONFIG_PATH = f"{_CONFIGS_DIR}/battery_overlay.yaml"
 
 BEACON_CONFIG_PATH: str = f"{_CONFIGS_DIR}/beacon.yaml"
 
-CARD_CONFIGS_PATH: dict[str, Optional[tuple[str, ...]]] = {
+CARD_CONFIGS_PATH: ConfigPaths = {
     "c3": (C3_CONFIG_PATH, SW_COMMON_CONFIG_PATH),
     "battery_1": (BAT_CONFIG_PATH, FW_COMMON_CONFIG_PATH, BAT_OVERLAY_CONFIG_PATH),
     "solar_1": (SOLAR_CONFIG_PATH, FW_COMMON_CONFIG_PATH),

--- a/oresat_configs/oresat0_5/__init__.py
+++ b/oresat_configs/oresat0_5/__init__.py
@@ -1,7 +1,6 @@
 """OreSat0.5 object dictionary and beacon constants."""
 
 import os
-from typing import Optional
 
 from ..base import (
     BAT_CONFIG_PATH,
@@ -15,13 +14,14 @@ from ..base import (
     SOLAR_CONFIG_PATH,
     ST_CONFIG_PATH,
     SW_COMMON_CONFIG_PATH,
+    ConfigPaths,
 )
 
 _CONFIGS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 BEACON_CONFIG_PATH: str = f"{_CONFIGS_DIR}/beacon.yaml"
 
-CARD_CONFIGS_PATH: dict[str, Optional[tuple[str, ...]]] = {
+CARD_CONFIGS_PATH: ConfigPaths = {
     "c3": (C3_CONFIG_PATH, SW_COMMON_CONFIG_PATH),
     "battery_1": (BAT_CONFIG_PATH, FW_COMMON_CONFIG_PATH),
     "solar_1": (SOLAR_CONFIG_PATH, FW_COMMON_CONFIG_PATH),

--- a/oresat_configs/oresat1/__init__.py
+++ b/oresat_configs/oresat1/__init__.py
@@ -1,7 +1,6 @@
 """OreSat1 object dictionary and beacon constants."""
 
 import os
-from typing import Optional
 
 from ..base import (
     BAT_CONFIG_PATH,
@@ -15,13 +14,14 @@ from ..base import (
     SOLAR_CONFIG_PATH,
     ST_CONFIG_PATH,
     SW_COMMON_CONFIG_PATH,
+    ConfigPaths,
 )
 
 _CONFIGS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 BEACON_CONFIG_PATH: str = f"{_CONFIGS_DIR}/beacon.yaml"
 
-CARD_CONFIGS_PATH: dict[str, Optional[tuple[str, ...]]] = {
+CARD_CONFIGS_PATH: ConfigPaths = {
     "c3": (C3_CONFIG_PATH, SW_COMMON_CONFIG_PATH),
     "battery_1": (BAT_CONFIG_PATH, FW_COMMON_CONFIG_PATH),
     "battery_2": (BAT_CONFIG_PATH, FW_COMMON_CONFIG_PATH),

--- a/oresat_configs/scripts/gen_dcf.py
+++ b/oresat_configs/scripts/gen_dcf.py
@@ -2,9 +2,10 @@
 
 from argparse import ArgumentParser, Namespace
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 import canopen
+from canopen.objectdictionary import Variable
 
 from .. import Consts, OreSatConfig
 
@@ -29,7 +30,7 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     return parser
 
 
-def register_subparser(subparsers):
+def register_subparser(subparsers: Any) -> None:
     """Registers an ArgumentParser as a subcommand of another parser.
 
     Intended to be called by __main__.py for each script. Given the output of add_subparsers(),
@@ -43,7 +44,7 @@ def register_subparser(subparsers):
     parser.set_defaults(func=gen_dcf)
 
 
-def write_od(od: canopen.ObjectDictionary, dir_path: str = "."):
+def write_od(od: canopen.ObjectDictionary, dir_path: str = ".") -> None:
     """Save an od/dcf file
 
     Parameters
@@ -167,7 +168,7 @@ def write_od(od: canopen.ObjectDictionary, dir_path: str = "."):
             f.write(line + "\n")
 
 
-def _objects_lines(od: canopen.ObjectDictionary, indexes: list) -> list:
+def _objects_lines(od: canopen.ObjectDictionary, indexes: list[int]) -> list[str]:
     lines = []
 
     for i in indexes:
@@ -182,7 +183,7 @@ def _objects_lines(od: canopen.ObjectDictionary, indexes: list) -> list:
     return lines
 
 
-def _variable_lines(variable: canopen.objectdictionary.Variable, index: int, subindex=None) -> list:
+def _variable_lines(variable: Variable, index: int, subindex: Optional[int] = None) -> list[str]:
     lines = []
 
     if subindex is None:
@@ -207,7 +208,7 @@ def _variable_lines(variable: canopen.objectdictionary.Variable, index: int, sub
     return lines
 
 
-def _array_lines(array: canopen.objectdictionary.Array, index: int) -> list:
+def _array_lines(array: canopen.objectdictionary.Array, index: int) -> list[str]:
     lines = []
 
     lines.append(f"[{index:X}]")
@@ -223,7 +224,7 @@ def _array_lines(array: canopen.objectdictionary.Array, index: int) -> list:
     return lines
 
 
-def _record_lines(record: canopen.objectdictionary.Record, index: int) -> list:
+def _record_lines(record: canopen.objectdictionary.Record, index: int) -> list[str]:
     lines = []
 
     lines.append(f"[{index:X}]")
@@ -239,7 +240,7 @@ def _record_lines(record: canopen.objectdictionary.Record, index: int) -> list:
     return lines
 
 
-def gen_dcf(args: Optional[Namespace] = None):
+def gen_dcf(args: Optional[Namespace] = None) -> None:
     """Gen_dcf main."""
     if args is None:
         args = build_parser(ArgumentParser()).parse_args()

--- a/oresat_configs/scripts/gen_xtce.py
+++ b/oresat_configs/scripts/gen_xtce.py
@@ -3,7 +3,7 @@
 import xml.etree.ElementTree as ET
 from argparse import ArgumentParser, Namespace
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 import canopen
 
@@ -29,7 +29,7 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     return parser
 
 
-def register_subparser(subparsers):
+def register_subparser(subparsers: Any) -> None:
     """Registers an ArgumentParser as a subcommand of another parser.
 
     Intended to be called by __main__.py for each script. Given the output of add_subparsers(),
@@ -89,7 +89,7 @@ def make_obj_name(obj: canopen.objectdictionary.Variable) -> str:
     return name
 
 
-def make_dt_name(obj) -> str:
+def make_dt_name(obj: canopen.objectdictionary.Variable) -> str:
     """Make xtce data type name."""
 
     type_name = CANOPEN_TO_XTCE_DT[obj.data_type]
@@ -111,7 +111,7 @@ def make_dt_name(obj) -> str:
     return type_name
 
 
-def write_xtce(config: OreSatConfig, dir_path: str = "."):
+def write_xtce(config: OreSatConfig, dir_path: str = ".") -> None:
     """Write beacon configs to a xtce file."""
 
     root = ET.Element(
@@ -344,7 +344,7 @@ def write_xtce(config: OreSatConfig, dir_path: str = "."):
     tree.write(f"{dir_path}/{file_name}", encoding="utf-8", xml_declaration=True)
 
 
-def gen_xtce(args: Optional[Namespace] = None):
+def gen_xtce(args: Optional[Namespace] = None) -> None:
     """Gen_dcf main."""
     if args is None:
         args = build_parser(ArgumentParser()).parse_args()

--- a/oresat_configs/scripts/list_cards.py
+++ b/oresat_configs/scripts/list_cards.py
@@ -3,11 +3,12 @@
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 from collections import defaultdict
 from dataclasses import asdict, fields
-from typing import Optional
+from typing import Any, Optional
 
 from tabulate import tabulate
 
-from .. import Card, Consts, cards_from_csv
+from ..card_info import Card, cards_from_csv
+from ..constants import Consts
 
 LIST_CARDS = "list oresat cards, suitable as arguments to other commands"
 
@@ -45,7 +46,7 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     return parser
 
 
-def register_subparser(subparsers):
+def register_subparser(subparsers: Any) -> None:
     """Registers an ArgumentParser as a subcommand of another parser.
 
     Intended to be called by __main__.py for each script. Given the output of add_subparsers(),
@@ -59,14 +60,14 @@ def register_subparser(subparsers):
     parser.set_defaults(func=list_cards)
 
 
-def list_cards(args: Optional[Namespace] = None):
+def list_cards(args: Optional[Namespace] = None) -> None:
     """Lists oresat cards and their configurations"""
     if args is None:
         args = build_parser(ArgumentParser()).parse_args()
 
     cards = cards_from_csv(Consts.from_string(args.oresat))
-    data = defaultdict(list)
-    data["name"] = cards.keys()
+    data: dict[str, list[str]] = defaultdict(list)
+    data["name"] = list(cards)
     for card in cards.values():
         for key, value in asdict(card).items():
             if key == "node_id":

--- a/oresat_configs/scripts/pdo.py
+++ b/oresat_configs/scripts/pdo.py
@@ -2,7 +2,7 @@
 
 import time
 from argparse import ArgumentParser, Namespace
-from typing import Optional
+from typing import Any, Optional
 
 import canopen
 
@@ -34,7 +34,7 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     return parser
 
 
-def register_subparser(subparsers):
+def register_subparser(subparsers: Any) -> None:
     """Registers an ArgumentParser as a subcommand of another parser.
 
     Intended to be called by __main__.py for each script. Given the output of add_subparsers(),
@@ -89,7 +89,7 @@ def transmission_type(t: int) -> str:
     raise ValueError(f"Invalid transmission type 0x{t:X}")
 
 
-def print_map(m: canopen.pdo.base.Map):
+def print_map(m: canopen.pdo.base.Map) -> None:
     """Prints out a received PDO.
 
     Which from this library means a PDO Mapping
@@ -102,7 +102,7 @@ def print_map(m: canopen.pdo.base.Map):
     print(f'{m.cob_id:03X} {m.name} {" ".join(data)}')
 
 
-def listen(bus: str, node_id: int, od: canopen.ObjectDictionary):
+def listen(bus: str, node_id: int, od: canopen.ObjectDictionary) -> None:
     """Listens for PDOs from the given node, formats and prints them to stdout"""
     network = canopen.Network()
     network.connect(channel=bus, bustype="socketcan")
@@ -121,7 +121,7 @@ def listen(bus: str, node_id: int, od: canopen.ObjectDictionary):
         network.disconnect()
 
 
-def listpdos(node_id: int, od: canopen.ObjectDictionary):
+def listpdos(node_id: int, od: canopen.ObjectDictionary) -> None:
     """Prints PDO communication and associated mapping parameters for the given node"""
 
     network = canopen.Network()
@@ -133,7 +133,7 @@ def listpdos(node_id: int, od: canopen.ObjectDictionary):
         print(f"PDO {index:2} {pdo.cob_id:03X} ({ttype}) => {names}")
 
 
-def pdo_main(args: Optional[Namespace] = None):
+def pdo_main(args: Optional[Namespace] = None) -> None:
     """The utility for managing PDOs"""
     if args is None:
         args = build_parser(ArgumentParser()).parse_args()

--- a/oresat_configs/scripts/print_od.py
+++ b/oresat_configs/scripts/print_od.py
@@ -28,7 +28,7 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     return parser
 
 
-def register_subparser(subparsers):
+def register_subparser(subparsers: Any) -> None:
     """Registers an ArgumentParser as a subcommand of another parser.
 
     Intended to be called by __main__.py for each script. Given the output of add_subparsers(),
@@ -45,13 +45,13 @@ def register_subparser(subparsers):
 def format_default(value: Any) -> str:
     """Format default value based off of python data type."""
     if isinstance(value, int) and not isinstance(value, bool):
-        value = hex(value)
-    elif isinstance(value, str):
-        value = f'"{value}"'
-    return value
+        return hex(value)
+    if isinstance(value, str):
+        return f'"{value}"'
+    return str(value)
 
 
-def print_od(args: Optional[Namespace] = None):
+def print_od(args: Optional[Namespace] = None) -> None:
     """The print-od main"""
     if args is None:
         args = build_parser(ArgumentParser()).parse_args()

--- a/oresat_configs/scripts/sdo_transfer.py
+++ b/oresat_configs/scripts/sdo_transfer.py
@@ -8,7 +8,7 @@ node's Object Dictionaries.
 import os
 import sys
 from argparse import ArgumentParser, Namespace
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import canopen
 
@@ -46,7 +46,7 @@ def build_parser(parser: ArgumentParser) -> ArgumentParser:
     return parser
 
 
-def register_subparser(subparsers):
+def register_subparser(subparsers: Any) -> None:
     """Registers an ArgumentParser as a subcommand of another parser.
 
     Intended to be called by __main__.py for each script. Given the output of add_subparsers(),
@@ -60,7 +60,7 @@ def register_subparser(subparsers):
     parser.set_defaults(func=sdo_transfer)
 
 
-def sdo_transfer(args: Optional[Namespace] = None):
+def sdo_transfer(args: Optional[Namespace] = None) -> None:
     """Read or write data to a node using a SDO."""
     if args is None:
         args = build_parser(ArgumentParser()).parse_args()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ path = "*/__init__.py"
 ignore = "W0611,R0903"
 
 [[tool.mypy.overrides]]
-module = "canopen,yaml"
+module = "canopen,canopen.objectdictionary"
 ignore_missing_imports = true
 
 [tool.isort]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ bitstring
 black
 build
 canopen
+dacite
 dataclasses-json
 isort
 pylama[all]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ isort
 pylama[all]
 pylama[toml]
 pyyaml
+types-pyyaml
 setuptools
 sphinx
 sphinx-rtd-theme

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,11 +12,11 @@ from oresat_configs._yaml_to_od import OD_DATA_TYPE_SIZE, TPDO_COMM_START, TPDO_
 class TestConfig(unittest.TestCase):
     """Base class to test a OreSat OD databases."""
 
-    def setUp(self):
-        self.id = Consts.ORESAT0
-        self.config = OreSatConfig(self.id)
+    def setUp(self) -> None:
+        self.oresatid = Consts.ORESAT0
+        self.config = OreSatConfig(self.oresatid)
 
-    def test_tpdo_sizes(self):
+    def test_tpdo_sizes(self) -> None:
         """Validate TPDO sizes."""
 
         for name in self.config.od_db:
@@ -43,11 +43,11 @@ class TestConfig(unittest.TestCase):
                         mapped_obj = mapped_obj[mapped_subindex]
                     self.assertTrue(
                         mapped_obj.pdo_mappable,
-                        f"{self.id.name} {name} {mapped_obj.name} is not pdo mappable",
+                        f"{self.oresatid.name} {name} {mapped_obj.name} is not pdo mappable",
                     )
                     size += OD_DATA_TYPE_SIZE[mapped_obj.data_type]
                 self.assertLessEqual(
-                    size, 64, f"{self.id.name} {name} TPDO{i + 1} is more than 64 bits"
+                    size, 64, f"{self.oresatid.name} {name} TPDO{i + 1} is more than 64 bits"
                 )
                 tpdos += 1
 
@@ -57,7 +57,7 @@ class TestConfig(unittest.TestCase):
             else:
                 self.assertLessEqual(tpdos, 16)
 
-    def test_beacon(self):
+    def test_beacon(self) -> None:
         """Test all objects reference in the beacon definition exist in the C3's OD."""
 
         length = 0
@@ -75,15 +75,15 @@ class TestConfig(unittest.TestCase):
                 self.assertNotIn(
                     obj.data_type,
                     dynamic_len_data_types,
-                    f"{self.id.name} {obj.name} is a dynamic length data type",
+                    f"{self.oresatid.name} {obj.name} is a dynamic length data type",
                 )
                 length += OD_DATA_TYPE_SIZE[obj.data_type] // 8  # bits to bytes
 
         # AX.25 payload max length = 255
         # CRC32 length = 4
-        self.assertLessEqual(length, 255 - 4, f"{self.id.name} beacon length too long")
+        self.assertLessEqual(length, 255 - 4, f"{self.oresatid.name} beacon length too long")
 
-    def test_record_array_length(self):
+    def test_record_array_length(self) -> None:
         """Test that array/record have is less than 255 objects in it."""
 
         for od in self.config.od_db.values():
@@ -91,13 +91,13 @@ class TestConfig(unittest.TestCase):
                 if not isinstance(od[index], canopen.objectdictionary.Variable):
                     self.assertLessEqual(len(od[index].subindices), 255)
 
-    def _test_snake_case(self, string: str):
+    def _test_snake_case(self, string: str) -> None:
         """Test that a string is snake_case."""
 
         regex_str = r"^[a-z][a-z0-9_]*[a-z0-9]*$"  # snake_case with no leading/trailing num or "_"
         self.assertIsNotNone(re.match(regex_str, string), f'"{string}" is not snake_case')
 
-    def _test_variable(self, obj: canopen.objectdictionary.Variable):
+    def _test_variable(self, obj: canopen.objectdictionary.Variable) -> None:
         """Test that a variable is valid."""
 
         self.assertIsInstance(obj, canopen.objectdictionary.Variable)
@@ -151,7 +151,7 @@ class TestConfig(unittest.TestCase):
 
         self.assertEqual(obj.default, obj.value)
 
-    def test_objects(self):
+    def test_objects(self) -> None:
         """Test that all objects are valid."""
 
         for name, od in self.config.od_db.items():

--- a/tests/test_config_types.py
+++ b/tests/test_config_types.py
@@ -1,0 +1,73 @@
+"""Unit tests for ensuring yaml config files match up with corresponding dataclasses"""
+
+import unittest
+from typing import Any
+
+from dacite import from_dict  # , Config
+from yaml import Loader, load
+
+from oresat_configs import _yaml_to_od, base, oresat0, oresat0_5, oresat1
+from oresat_configs.beacon_config import BeaconConfig
+from oresat_configs.card_config import CardConfig, IndexObject
+
+
+class ConfigTypes(unittest.TestCase):
+    """Tests for yaml config files
+
+    For each yaml config there should be a test that turns it into a dataclass but not
+    necessarily the other way around. There are dataclasses that don't correspond to a config or
+    only a portion of the config.
+    """
+
+    @staticmethod
+    def load_yaml(path: str) -> Any:
+        """Helper that wraps loading yaml from a path"""
+        with open(path) as f:
+            config = f.read()
+        return load(config, Loader=Loader)
+
+    def dtype_subtest(self, path: str, dtype: Any, data: Any) -> None:
+        """The main check that gets done, creates a new subtest for each check"""
+        with self.subTest(path=path, dtype=dtype):
+            # raises WrongTypeError if the types don't check out
+            # when we're ready, use the config below to ensure every yaml field is consumed
+            from_dict(dtype, data)  # , Config(strict=True, strict_unions_match=True))
+
+    def check_types(self, path: str, dtype: Any) -> None:
+        """Helper that combines load_yaml() and dtype_subtest()"""
+        self.dtype_subtest(path, dtype, self.load_yaml(path))
+
+    def test_beacon_config(self) -> None:
+        """Tests all the beacon configs, with dataclass BeaconConfig"""
+        beacon_paths = [
+            oresat0.BEACON_CONFIG_PATH,
+            oresat0_5.BEACON_CONFIG_PATH,
+            oresat1.BEACON_CONFIG_PATH,
+        ]
+        for path in beacon_paths:
+            self.check_types(path, BeaconConfig)
+
+    def test_card_config(self) -> None:
+        """Tests all the card configs, with dataclass CardConfig"""
+        card_paths = [
+            base.FW_COMMON_CONFIG_PATH,
+            base.SW_COMMON_CONFIG_PATH,
+            base.C3_CONFIG_PATH,
+            base.BAT_CONFIG_PATH,
+            base.SOLAR_CONFIG_PATH,
+            base.IMU_CONFIG_PATH,
+            base.RW_CONFIG_PATH,
+            base.GPS_CONFIG_PATH,
+            base.ST_CONFIG_PATH,
+            base.DXWIFI_CONFIG_PATH,
+            base.CFC_CONFIG_PATH,
+            oresat0.BAT_OVERLAY_CONFIG_PATH,
+        ]
+        for path in card_paths:
+            self.check_types(path, CardConfig)
+
+    def test_standard_types(self) -> None:
+        """Tests the standard objects config. Each entry gets its own IndexObject"""
+        path = _yaml_to_od.STD_OBJS_FILE_NAME
+        for data in self.load_yaml(path):
+            self.dtype_subtest(path, IndexObject, data)

--- a/tests/test_oresat0.py
+++ b/tests/test_oresat0.py
@@ -8,6 +8,6 @@ from . import TestConfig
 class TestOreSat0(TestConfig):
     """Test the OreSat0 OD database."""
 
-    def setUp(self):
-        self.id = Consts.ORESAT0
-        self.config = OreSatConfig(self.id)
+    def setUp(self) -> None:
+        self.oresatid = Consts.ORESAT0
+        self.config = OreSatConfig(self.oresatid)

--- a/tests/test_oresat0_5.py
+++ b/tests/test_oresat0_5.py
@@ -8,6 +8,6 @@ from . import TestConfig
 class TestOreSat0_5(TestConfig):
     """Test the OreSat0.5 OD database"""
 
-    def setUp(self):
-        self.id = Consts.ORESAT0_5
-        self.config = OreSatConfig(self.id)
+    def setUp(self) -> None:
+        self.oresatid = Consts.ORESAT0_5
+        self.config = OreSatConfig(self.oresatid)

--- a/tests/test_oresat1.py
+++ b/tests/test_oresat1.py
@@ -1,0 +1,13 @@
+"""Unit tests for OreSat1 OD database."""
+
+from oresat_configs import Consts, OreSatConfig
+
+from . import TestConfig
+
+
+class TestOreSat1(TestConfig):
+    """Test the OreSat1 OD database"""
+
+    def setUp(self):
+        self.id = Consts.ORESAT1
+        self.config = OreSatConfig(self.id)

--- a/tests/test_oresat1.py
+++ b/tests/test_oresat1.py
@@ -8,6 +8,6 @@ from . import TestConfig
 class TestOreSat1(TestConfig):
     """Test the OreSat1 OD database"""
 
-    def setUp(self):
-        self.id = Consts.ORESAT1
-        self.config = OreSatConfig(self.id)
+    def setUp(self) -> None:
+        self.oresatid = Consts.ORESAT1
+        self.config = OreSatConfig(self.oresatid)


### PR DESCRIPTION
This adds a couple of tests, some type information and introduces the `dacite` package for converting from dicts to dataclasses.

This shouldn't add any new behavior (beyond minor bug fixes - see the description of 4ff2a0c). The bulk of the changes are type information, especially adding `-> None` to functions that don't have an explicit `return`. The type information involved is enough to get it to pass `mypy --strict`, and prepares it for being PEP-561 compliant (specifically `py.typed`). Making it actually fully compliant I felt was beyond the scope of this PR.