### PR TITLE
Faster OreSatConfig() creation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,15 +15,17 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "3.9"
+        cache: "pip"
 
     - name: Install dependencies
       run: |
+        sudo apt install libyaml-0-2
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,29 @@ transfers.
 
 ## Setup
 
-Install project dev dependencies.
+Install project dev dependencies. `libyaml` should be installed by default on
+reasonable systems, but it never hurts to make sure.
 
 ```bash
+$ sudo apt install libyaml-0-2
 $ pip install -r requirements.txt
+```
+
+If installing on ARM (e.g. Octavo cards like the C3) special work is needed to
+ensure that `pyyaml` uses the `libyaml` C bindings. The binary wheels from PyPI
+aren't built with them so we need to install from the source package:
+
+Installing the first time:
+```bash
+$ sudo apt install libyaml-dev
+$ pip install --no-binary pyyaml -r requirements.txt
+```
+
+Fixing an already installed pyyaml: (see here if you get "ImportError: pyyaml
+missing/installed without libyaml bindings.")
+```bash
+$ sudo apt install libyaml-dev
+$ pip install --no-cache-dir --no-binary pyyaml pyyaml
 ```
 
 ## Updating a Config

--- a/oresat_configs/__init__.py
+++ b/oresat_configs/__init__.py
@@ -1,5 +1,16 @@
 """OreSat OD database"""
 
+# Checks that pyyaml is installed correctly. For performance reasons it must use the libyaml C
+# bindings. To use them both libyaml must be installed on the local system, and pyyaml must have
+# been built to use them. This works correctly on x86 systems, but on arm pyyaml is built by
+# default to not include the bindings.
+try:
+    from yaml import CLoader
+except ImportError as e:
+    raise ImportError(
+        "pyyaml missing/installed without libyaml bindings. See oresat-configs README.md for more"
+    ) from e
+
 from dataclasses import dataclass
 from typing import Union
 

--- a/oresat_configs/_yaml_to_od.py
+++ b/oresat_configs/_yaml_to_od.py
@@ -2,20 +2,13 @@
 
 import os
 from copy import deepcopy
-from typing import Any, Union
+from typing import Union
 
 import canopen
 from canopen import ObjectDictionary
 from canopen.objectdictionary import Array, Record, Variable
-from yaml import load
-
-Loader: Any
-try:
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Loader
-
 from dacite import from_dict
+from yaml import CLoader, load
 
 from .base import ConfigPaths
 from .beacon_config import BeaconConfig
@@ -476,7 +469,7 @@ def _load_std_objs(
     """Load the standard objects."""
 
     with open(file_path, "r") as f:
-        std_objs_raw = load(f, Loader=Loader)
+        std_objs_raw = load(f, Loader=CLoader)
 
     std_objs = {}
     for obj_raw in std_objs_raw:

--- a/oresat_configs/_yaml_to_od.py
+++ b/oresat_configs/_yaml_to_od.py
@@ -15,6 +15,8 @@ try:
 except ImportError:
     from yaml import Loader
 
+from dacite import from_dict
+
 from .base import ConfigPaths
 from .beacon_config import BeaconConfig
 from .card_config import CardConfig, ConfigObject, IndexObject, SubindexObject
@@ -478,7 +480,7 @@ def _load_std_objs(
 
     std_objs = {}
     for obj_raw in std_objs_raw:
-        obj = IndexObject.from_dict(obj_raw)  # pylint: disable=E1101
+        obj = from_dict(data_class=IndexObject, data=obj_raw)
         if obj.object_type == "variable":
             std_objs[obj.name] = _make_var(obj, obj.index)
         elif obj.object_type == "record":

--- a/oresat_configs/beacon_config.py
+++ b/oresat_configs/beacon_config.py
@@ -13,10 +13,9 @@ try:
 except ImportError:
     from yaml import Loader
 
-from dataclasses_json import dataclass_json
+from dacite import from_dict
 
 
-@dataclass_json
 @dataclass
 class BeaconAx25Config:
     """
@@ -55,7 +54,6 @@ class BeaconAx25Config:
     """If set to True, the C-bit in source field."""
 
 
-@dataclass_json
 @dataclass
 class BeaconConfig:
     """
@@ -95,4 +93,4 @@ class BeaconConfig:
 
         with open(config_path, "r") as f:
             config_raw = load(f, Loader=Loader)
-        return cls.from_dict(config_raw)  # type: ignore  # pylint: disable=E1101
+        return from_dict(data_class=cls, data=config_raw)

--- a/oresat_configs/beacon_config.py
+++ b/oresat_configs/beacon_config.py
@@ -3,17 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
-
-from yaml import load
-
-Loader: Any
-try:
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Loader
 
 from dacite import from_dict
+from yaml import CLoader, load
 
 
 @dataclass
@@ -92,5 +84,5 @@ class BeaconConfig:
         """Load a beacon YAML config file."""
 
         with open(config_path, "r") as f:
-            config_raw = load(f, Loader=Loader)
+            config_raw = load(f, Loader=CLoader)
         return from_dict(data_class=cls, data=config_raw)

--- a/oresat_configs/card_config.py
+++ b/oresat_configs/card_config.py
@@ -13,10 +13,9 @@ try:
 except ImportError:
     from yaml import Loader
 
-from dataclasses_json import dataclass_json
+from dacite import from_dict
 
 
-@dataclass_json
 @dataclass
 class ConfigObject:
     """Object in config."""
@@ -52,7 +51,6 @@ class ConfigObject:
     """
 
 
-@dataclass_json
 @dataclass
 class GenerateSubindex(ConfigObject):
     """
@@ -81,7 +79,6 @@ class GenerateSubindex(ConfigObject):
     """Subindexes of objects to generate."""
 
 
-@dataclass_json
 @dataclass
 class SubindexObject(ConfigObject):
     """
@@ -107,7 +104,6 @@ class SubindexObject(ConfigObject):
     """
 
 
-@dataclass_json
 @dataclass
 class IndexObject(ConfigObject):
     """
@@ -137,7 +133,6 @@ class IndexObject(ConfigObject):
     """Used to generate subindexes for arrays."""
 
 
-@dataclass_json
 @dataclass
 class Tpdo:
     """
@@ -176,7 +171,6 @@ class Tpdo:
     """Index and subindexes of objects to map to the TPDO."""
 
 
-@dataclass_json
 @dataclass
 class Rpdo:
     """
@@ -200,7 +194,6 @@ class Rpdo:
     """TPDO number, 1-16."""
 
 
-@dataclass_json
 @dataclass
 class CardConfig:
     """
@@ -250,4 +243,4 @@ class CardConfig:
 
         with open(config_path, "r") as f:
             config_raw = load(f, Loader=Loader)
-        return cls.from_dict(config_raw)  # type: ignore  # pylint: disable=E1101
+        return from_dict(data_class=cls, data=config_raw)

--- a/oresat_configs/card_config.py
+++ b/oresat_configs/card_config.py
@@ -6,15 +6,8 @@ from dataclasses import dataclass, field
 from functools import cache
 from typing import Any, Optional, Union
 
-from yaml import load
-
-Loader: Any
-try:
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Loader
-
 from dacite import from_dict
+from yaml import CLoader, load
 
 
 @dataclass
@@ -244,5 +237,5 @@ class CardConfig:
         """Load a card YAML config file."""
 
         with open(config_path, "r") as f:
-            config_raw = load(f, Loader=Loader)
+            config_raw = load(f, Loader=CLoader)
         return from_dict(data_class=cls, data=config_raw)

--- a/oresat_configs/card_config.py
+++ b/oresat_configs/card_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from functools import cache
 from typing import Any, Optional, Union
 
 from yaml import load
@@ -238,6 +239,7 @@ class CardConfig:
     """C3 only. List of index and subindex for the c3 to save the values of to F-RAM."""
 
     @classmethod
+    @cache
     def from_yaml(cls, config_path: str) -> CardConfig:
         """Load a card YAML config file."""
 

--- a/oresat_configs/card_info.py
+++ b/oresat_configs/card_info.py
@@ -4,12 +4,9 @@ import csv
 import os
 from dataclasses import dataclass
 
-from dataclasses_json import dataclass_json
-
 from .constants import Consts
 
 
-@dataclass_json
 @dataclass
 class Card:
     """Card info."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,21 +6,19 @@ build-backend = "setuptools.build_meta"
 name = "oresat-configs"
 description = "OreSat mission configurations"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 license = {text = "GPL-3.0"}
 classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     "canopen",
-    "dataclasses-json",
+    "dacite",
     "pyyaml",
 ]
 dynamic = ["version"]
@@ -47,7 +45,7 @@ line_length = 100
 
 [tool.pylama]
 format = "pylint"
-skip = "*/.tox/*,*/.env/,*/.git/*,*/.github/*,*/build/*"
+skip = "*/.tox/*,*/.env/,*/.git/*,*/.github/*,*/build/*,.direnv/*"
 linters = "pycodestyle,pyflakes,pylint,mccabe,mypy,radon"
 # E402:     Module level import not at top of file
 # C901:     Function is too complex

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ black
 build
 canopen
 dacite
-dataclasses-json
 isort
 pylama[all]
 pylama[toml]


### PR DESCRIPTION
This contains the changes so far discussed in #14. The major features:

- Replaces `dataclasses_json` with `dacite`. Now that this project no longer uses JSON the `dataclasses_json` package was only being used for dict -> dataclass conversion. The `dacite` package does this much faster.
- [Memoizes](https://en.wikipedia.org/wiki/Memoization) CardConfig.from_yaml(). Trades a bit of space for a lot of time.
- Ensures that pyyaml uses the libyaml C bindings. This is unfortunately a bit of a manual process and until pyyaml is re-installed correctly users will see an `ImportError` directing them to the README for further instructions. I tried to make this a more automatic process through pip installs but my brain boggles every time I try to do complex python packaging stuff.