### PR TITLE
Update README.md pyyaml arm reinstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Fixing an already installed pyyaml: (see here if you get "ImportError: pyyaml
 missing/installed without libyaml bindings.")
 ```bash
 $ sudo apt install libyaml-dev
-$ pip install --no-cache-dir --no-binary pyyaml pyyaml
+$ pip install --force-reinstall --no-cache-dir --no-binary pyyaml pyyaml
 ```
 
 ## Updating a Config


### PR DESCRIPTION
The previous instructions had assumed that while pyyaml had been installed previously, it was also currently uninstalled.

This updates it to handle both the installed and uninstalled cases