### PR TITLE
Fix installed scripts, add test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,3 +46,15 @@ jobs:
 
     - name: Test building sphinx docs
       run: make -C docs html
+
+    - name: Test installed scripts
+      run: |
+        pip install dist/*.whl
+        oresat-configs > /dev/null
+        oresat-gen-fw-files c3
+        oresat-gen-dcf c3
+        oresat-print-od c3 > /dev/null
+        oresat-gen-xtce
+        oresat-configs cards > /dev/null
+        oresat-configs pdo c3 --list > /dev/null
+        pip uninstall -y oresat-configs

--- a/oresat_configs/__main__.py
+++ b/oresat_configs/__main__.py
@@ -49,7 +49,11 @@ _SCRIPTS = [
 ]
 
 
-if __name__ == "__main__":
+def oresat_configs():
+    """Entry point for the top level script
+
+    Used in pyproject.toml, for generating the oresat-configs installed script
+    """
     parser = argparse.ArgumentParser(prog="oresat_configs")
     parser.add_argument("--version", action="version", version="%(prog)s v" + __version__)
     parser.set_defaults(func=lambda x: parser.print_help())
@@ -60,3 +64,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     args.func(args)
+
+
+if __name__ == "__main__":
+    oresat_configs()


### PR DESCRIPTION
In 3404899 as part of a cleanup I removed the `oresat_configs()` function in `__main__.py`. It turns out that this function was being used, as the entry point for the installed oresat-configs script.

In order to not break it again I've added a CI test that runs the expected installed scripts. It's not an exhaustive system test, more of a simple smoke test to make sure they don't crash.