### PR TITLE
Validate XTCE output

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt install libyaml-0-2
+        sudo apt update
+        sudo apt install -y libyaml-0-2 libxml2-utils
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
@@ -55,6 +56,8 @@ jobs:
         oresat-gen-dcf c3
         oresat-print-od c3 > /dev/null
         oresat-gen-xtce
+        curl -O https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd
+        xmllint --noout --schema SpaceSystem.xsd oresat0_5.xtce
         oresat-configs cards > /dev/null
         oresat-configs pdo c3 --list > /dev/null
         pip uninstall -y oresat-configs

--- a/oresat_configs/constants.py
+++ b/oresat_configs/constants.py
@@ -47,6 +47,13 @@ class Consts(Mission, Enum):
     def __str__(self) -> str:
         return "OreSat" + self.arg
 
+    def filename(self) -> str:
+        """Returns a string safe to use in filenames and other restricted settings.
+
+        All lower case, dots replaced with underscores.
+        """
+        return str(self).lower().replace(".", "_")
+
     @classmethod
     def default(cls) -> Consts:
         """Returns the currently active mission"""

--- a/oresat_configs/scripts/gen_xtce.py
+++ b/oresat_configs/scripts/gen_xtce.py
@@ -117,8 +117,8 @@ def write_xtce(config: OreSatConfig, dir_path: str = ".") -> None:
     root = ET.Element(
         "SpaceSystem",
         attrib={
-            "name": str(config.mission),
-            "xmlns:xtce": "http://www.omg.org/space/xtce",
+            "name": config.mission.filename(),
+            "xmlns": "http://www.omg.org/spec/XTCE/20180204",
             "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
             "xsi:schemaLocation": (
                 "http://www.omg.org/spec/XTCE/20180204 "
@@ -175,7 +175,7 @@ def write_xtce(config: OreSatConfig, dir_path: str = ".") -> None:
             "shortDescription": "Unix coarse timestamp",
         },
     )
-    enc = ET.SubElement(para_type, "Encodings")
+    enc = ET.SubElement(para_type, "Encoding")
     ET.SubElement(
         enc,
         "IntegerDataEncoding",
@@ -340,7 +340,7 @@ def write_xtce(config: OreSatConfig, dir_path: str = ".") -> None:
     # write
     tree = ET.ElementTree(root)
     ET.indent(tree, space="  ", level=0)
-    file_name = f"{config.mission.name.lower()}.xtce"
+    file_name = f"{config.mission.filename()}.xtce"
     tree.write(f"{dir_path}/{file_name}", encoding="utf-8", xml_declaration=True)
 
 


### PR DESCRIPTION
Adds a test that will validate the generated oresat xtce against the official xtce schema. This caught three minor issues in our generator:
- The root `name` attribute doesn't like dots in its string. 63f87669 broke this when refactoring the mission names, this restores the old behavior.
- The XML namespace was incorrect. It pointed to the old version of XTCE which had been changed in the new schema. It also required `xtce` to be the prefix for every tag, which we weren't doing. Dropping it means the whole document is assumed to be in that namespace so we don't have to go through the hassle of prefixing every tag.
- Encodings -> Encoding.

The schema check in CI could be more elegant, I've just hardcoded both fetching the schema and the output file for now but they probably should be determined dynamically eventually.