### PR TITLE
Fix generator bugs

### DIFF
--- a/oresat_configs/scripts/gen_kaitai.py
+++ b/oresat_configs/scripts/gen_kaitai.py
@@ -61,7 +61,6 @@ CANOPEN_TO_KAITAI_DT = {
 }
 
 
-
 def write_kaitai(config: OreSatConfig, dir_path: str = ".") -> None:
     """Write beacon configs to a kaitai file."""
 
@@ -209,7 +208,7 @@ def write_kaitai(config: OreSatConfig, dir_path: str = ".") -> None:
 
     # Append field types for each field
     payload_size = 0
-    
+
     for obj in config.beacon_def:
         name = (
             "_".join([obj.parent.name, obj.name])
@@ -226,7 +225,7 @@ def write_kaitai(config: OreSatConfig, dir_path: str = ".") -> None:
             new_var["encoding"] = "ASCII"
             if obj.access_type == "const":
                 new_var["size"] = len(obj.default)
-            payload_size += new_var["size"] * 8     
+            payload_size += new_var["size"] * 8
         else:
             payload_size += len(obj)
 
@@ -235,7 +234,6 @@ def write_kaitai(config: OreSatConfig, dir_path: str = ".") -> None:
     payload_size //= 8
     kaitai_data["types"]["i_frame"]["seq"][1]["size"] = payload_size
     kaitai_data["types"]["ui_frame"]["seq"][1]["size"] = payload_size
-
 
     # Write kaitai to output file
     with open(f"{dir_path}/{filename}.ksy", "w+") as file:


### PR DESCRIPTION
# Problem Statement:

Theo and I discovered several bugs with the kaitai generator which caused incorrect packet parsing or straight-out crashing of the parser

# Updates:

* AX25 Info payload would incorrectly read to the end of the packet
  * Disabling the CRC from being loaded
* Callsign processor type was set to non-existant `repeater` type instead of the satnogs recommended `ror(1)` (right-shifting the callsign bytestring)
* Add dynamic payload-size calculation while populating AX25 Info Data frame

# Impact:

Kaitai struct is ready for release to SatNOGS DB + Network