### PR TITLE
Add enums and bitfields to generate OD.h and fix #defines

### DIFF
--- a/oresat_configs/_yaml_to_od.py
+++ b/oresat_configs/_yaml_to_od.py
@@ -98,10 +98,9 @@ def _parse_bit_definitions(obj: Union[IndexObject, SubindexObject]) -> dict[str,
         elif isinstance(bits, list):
             bit_defs[name] = list(sorted(bits))
         elif isinstance(bits, str) and "-" in bits:
-            low, high = bits.split("-")
-            low, high = (low, high) if low < high else (high, low)
-            bit_defs[name] = list(range(int(low), int(high) + 1))
-    sorted_bit_defs_keys = sorted(bit_defs, key=lambda k: max(bit_defs.get(k)))
+            bits_ints = [int(i) for i in bits.split("-")]
+            bit_defs[name] = list(range(min(bits_ints), max(bits_ints) + 1))
+    sorted_bit_defs_keys = sorted(bit_defs, key=lambda k: max(bit_defs[k]))
     return {key: bit_defs[key] for key in sorted_bit_defs_keys}
 
 

--- a/oresat_configs/_yaml_to_od.py
+++ b/oresat_configs/_yaml_to_od.py
@@ -90,12 +90,26 @@ def _set_var_default(obj: ConfigObject, var: Variable) -> None:
     var.default = default
 
 
+def _parse_bit_definitions(obj: Union[IndexObject, SubindexObject]) -> dict[str, list[int]]:
+    bit_defs = {}
+    for name, bits in obj.bit_definitions.items():
+        if isinstance(bits, int):
+            bit_defs[name] = [bits]
+        elif isinstance(bits, list):
+            bit_defs[name] = list(sorted(bits))
+        elif isinstance(bits, str) and "-" in bits:
+            low, high = bits.split("-")
+            low, high = (low, high) if low < high else (high, low)
+            bit_defs[name] = list(range(int(low), int(high) + 1))
+    sorted_bit_defs_keys = sorted(bit_defs, key=lambda k: max(bit_defs.get(k)))
+    return {key: bit_defs[key] for key in sorted_bit_defs_keys}
+
+
 def _make_var(obj: Union[IndexObject, SubindexObject], index: int, subindex: int = 0) -> Variable:
     var = canopen.objectdictionary.Variable(obj.name, index, subindex)
     var.access_type = obj.access_type
     var.description = obj.description
-    for name, bits in obj.bit_definitions.items():
-        var.add_bit_definition(name, bits)
+    var.bit_definitions = _parse_bit_definitions(obj)
     for name, value in obj.value_descriptions.items():
         var.add_value_description(value, name)
     var.unit = obj.unit

--- a/oresat_configs/_yaml_to_od.py
+++ b/oresat_configs/_yaml_to_od.py
@@ -98,10 +98,9 @@ def _parse_bit_definitions(obj: Union[IndexObject, SubindexObject]) -> dict[str,
         elif isinstance(bits, list):
             bit_defs[name] = list(sorted(bits))
         elif isinstance(bits, str) and "-" in bits:
-            bits_ints = [int(i) for i in bits.split("-")]
-            bit_defs[name] = list(range(min(bits_ints), max(bits_ints) + 1))
-    sorted_bit_defs_keys = sorted(bit_defs, key=lambda k: max(bit_defs[k]))
-    return {key: bit_defs[key] for key in sorted_bit_defs_keys}
+            low, high = sorted([int(i) for i in bits.split("-")])
+            bit_defs[name] = list(range(low, high + 1))
+    return bit_defs
 
 
 def _make_var(obj: Union[IndexObject, SubindexObject], index: int, subindex: int = 0) -> Variable:

--- a/oresat_configs/base/diode_test.yaml
+++ b/oresat_configs/base/diode_test.yaml
@@ -20,7 +20,7 @@ objects:
           dtc_muxEnable: 7
           dtc_muxDisable: 8
           dtc_clearErrors: 9
-        access_type: rw 
+        access_type: rw
 
       - subindex: 0x2
         name: mux_select
@@ -29,23 +29,23 @@ objects:
         low_limit: 0x0
         default: 0x0
         description: diode mux select
-        access_type: rw 
+        access_type: rw
 
       - subindex: 0x3
-        name: dac 
+        name: dac
         data_type: uint16
         high_limit: 0xFFF
         low_limit: 0x0
         default: 0x0
         description: dac output
-        access_type: rw 
+        access_type: rw
 
       - subindex: 0x4
         name: status
         data_type: uint16
         default: 0x0
         description: status bits
-        access_type: rw 
+        access_type: rw
         bit_definitions:
            DAC_EN: 0
            GPT_EN: 1
@@ -60,7 +60,7 @@ objects:
         data_type: uint16
         default: 0x0
         description: error bits
-        access_type: rw 
+        access_type: rw
         bit_definitions:
           DAC: 0
           ADC_CB: 1
@@ -68,7 +68,7 @@ objects:
           ADC_STOP: 3
 
   - index: 0x4001
-    name: adcsample 
+    name: adcsample
     description: adc samples
     object_type: record
     subindexes:
@@ -76,21 +76,21 @@ objects:
         name: led_current
         data_type: uint16
         description: led feedback current
-        access_type: rw 
+        access_type: rw
         unit: lsb
 
       - subindex: 0x2
         name: led_swir_pd_current
         data_type: uint16
         description: swir feedback current
-        access_type: rw 
+        access_type: rw
         unit: lsb
 
       - subindex: 0x3
         name: uv_pd_current
         data_type: uint16
         description: uv feedback current
-        access_type: rw 
+        access_type: rw
         unit: lsb
 
 tpdos:

--- a/oresat_configs/base/dxwifi.yaml
+++ b/oresat_configs/base/dxwifi.yaml
@@ -33,7 +33,7 @@ objects:
         data_type: uint8
         description: amount of images to capture in succession
         default: 1
-      
+
       - subindex: 0x2
         name: delay
         data_type: uint32
@@ -70,7 +70,7 @@ objects:
         data_type: uint8
         description: hue level of capture (0, 64)
         default: 0
-      
+
       - subindex: 0x8
         name: gamma
         data_type: uint8
@@ -112,7 +112,7 @@ objects:
         data_type: bool
         description: enables the power amplifier
         default: False
-      
+
 
 tpdos:
   - num: 3

--- a/oresat_configs/base/fw_common.yaml
+++ b/oresat_configs/base/fw_common.yaml
@@ -44,7 +44,7 @@ objects:
         description: oresat configs version
         access_type: const
         default: "0.0.0"
-  
+
       # subindex 0x3 reserved
 
       - subindex: 0x4
@@ -58,24 +58,47 @@ objects:
     name: system
     object_type: record
     subindexes:
-      # subindex 0x1 reserved for reset
+      - subindex: 0x1
+        name: reset
+        data_type: uint8
+        description: reset the app
+        value_descriptions:
+          no_stop: 0
+          soft_reset: 1
+          hard_reset: 2
+          factory_reset: 3
+          poweroff: 4
+        access_type: wo
+
       # subindex 0x2 reserved for storage_percent
       # subindex 0x3 reserved for ram_percent
       # subindex 0x4 reserved for unix_time
-      # subindex 0x5 reserved for uptime
+
+      - subindex: 0x5
+        name: uptime
+        data_type: uint32
+        description: uptime
+        access_type: ro
+        unit: s
+
       # subindex 0x6 reserved for power_cycles
 
       - subindex: 0x7
         name: temperature
         data_type: int8
-        description: the temperature of the processor
+        description: processor temperature
         access_type: ro
         unit: C
 
       - subindex: 0x8
         name: vrefint
-        data_type: uint8
+        description: processor internal voltage reference
+        data_type: uint16
         access_type: ro
+        scale_factor: 0.001
+        unit: V
+
+      # subindex 0x9 reserved for boot_select
 
   # index 0x3004 reserved
   # index 0x3005 reserved

--- a/oresat_configs/base/reaction_wheel.yaml
+++ b/oresat_configs/base/reaction_wheel.yaml
@@ -147,26 +147,26 @@ objects:
 
 tpdos:
   - num: 1
-    fields: 
+    fields:
       - [ctrl_stat, current_state]
       - [ctrl_stat, procedure_result]
       - [ctrl_stat, errors]
     event_timer_ms: 100
 
   - num: 2
-    fields: 
+    fields:
       - [motor, velocity]
       - [motor, current]
     event_timer_ms: 100
 
   - num: 3
-    fields: 
+    fields:
       - [bus, voltage]
       - [bus, current]
     event_timer_ms: 100
-      
+
   - num: 4
-    fields: 
+    fields:
       - [temperature, sensor_1]
       - [temperature, sensor_2]
       - [temperature, sensor_3]

--- a/oresat_configs/base/solar.yaml
+++ b/oresat_configs/base/solar.yaml
@@ -127,9 +127,9 @@ objects:
   - index: 0x4003
     name: mppt_alg
     data_type: uint8
-    description: |
-      mppt (maximum power point tracking) algorithm
-      - 0: perturb and observse
+    description: mppt (maximum power point tracking) algorithm
+    value_descriptions:
+      perturb_and_observse: 0
     access_type: rw
 
   - index: 0x4004

--- a/oresat_configs/base/solar.yaml
+++ b/oresat_configs/base/solar.yaml
@@ -129,7 +129,7 @@ objects:
     data_type: uint8
     description: mppt (maximum power point tracking) algorithm
     value_descriptions:
-      perturb_and_observse: 0
+      perturb_and_observe: 0
     access_type: rw
 
   - index: 0x4004

--- a/oresat_configs/base/star_tracker.yaml
+++ b/oresat_configs/base/star_tracker.yaml
@@ -121,7 +121,7 @@ objects:
         data_type: uint8
         description: percentage of pixels must be above lower bound
         access_type: rw
-        upper_limit: 100
+        high_limit: 100
 
       - subindex: 0x4
         name: upper_bound
@@ -134,7 +134,7 @@ objects:
         data_type: uint8
         description: percentage of pixels must be above upper bound
         access_type: rw
-        upper_limit: 100
+        high_limit: 100
 
 tpdos:
   - num: 3

--- a/oresat_configs/scripts/gen_fw_files.py
+++ b/oresat_configs/scripts/gen_fw_files.py
@@ -605,18 +605,16 @@ def write_canopennode_h(od: canopen.ObjectDictionary, dir_path: str = ".") -> No
     lines.append("")
 
     lines.append("#define OD_CNT_NMT 1")
-    lines.append("#define OD_CNT_EM 1")
-    lines.append("#define OD_CNT_SYNC 1")
-    lines.append("#define OD_CNT_EM_PROD 1")
     lines.append("#define OD_CNT_HB_PROD 1")
-    lines.append("#define OD_CNT_HB_CONS 0")
-    lines.append("#define OD_CNT_SDO_SRV 1")
-    if 0x1280 in od:
-        lines.append("#define OD_CNT_SDO_CLI 1")
-    if od.device_information.nr_of_RXPDO > 0:
-        lines.append(f"#define OD_CNT_RPDO {od.device_information.nr_of_RXPDO}")
-    if od.device_information.nr_of_TXPDO > 0:
-        lines.append(f"#define OD_CNT_TPDO {od.device_information.nr_of_TXPDO}")
+    lines.append(f"#define OD_CNT_HB_CONS {int(0x1016 in od)}")
+    lines.append("#define OD_CNT_EM 1")
+    lines.append("#define OD_CNT_EM_PROD 1")
+    lines.append(f"#define OD_CNT_SDO_SRV {int(0x1200 in od)}")
+    lines.append(f"#define OD_CNT_SDO_CLI {int(0x1280 in od)}")
+    lines.append(f"#define OD_CNT_TIME {int(0x1012 in od)}")
+    lines.append(f"#define OD_CNT_SYNC {int(0x1005 in od and 0x1006 in od)}")
+    lines.append(f"#define OD_CNT_RPDO {od.device_information.nr_of_RXPDO}")
+    lines.append(f"#define OD_CNT_TPDO {od.device_information.nr_of_TXPDO}")
     lines.append("")
 
     for i in od:

--- a/oresat_configs/scripts/gen_fw_files.py
+++ b/oresat_configs/scripts/gen_fw_files.py
@@ -665,7 +665,7 @@ def _make_bitfields_lines(obj: canopen.objectdictionary.Variable) -> list[str]:
 
     data_type = DATA_TYPE_C_TYPES[obj.data_type]
     bitfield_name = obj_name + "_bitfield"
-    lines.append(f"union {bitfield_name} " + "{")
+    lines.append(f"typedef union {bitfield_name} " + "{")
     lines.append(f"{INDENT4}{data_type} value;")
     lines.append(INDENT4 + "struct __attribute((packed)) {")
     total_bits = 0
@@ -684,9 +684,9 @@ def _make_bitfields_lines(obj: canopen.objectdictionary.Variable) -> list[str]:
         unused_bits = DATA_TYPE_C_SIZE[obj.data_type] - total_bits
         lines.append(f"{INDENT8}{data_type} unused{total_bits} : {unused_bits};")
     lines.append(INDENT4 + "} fields;")
-    lines.append("};")
+    lines.append("} " + f"{bitfield_name}_t;")
     lines.append(
-        f"static_assert(sizeof({bitfield_name}) == sizeof({data_type}), "
+        f"static_assert(sizeof({bitfield_name}_t) == sizeof({data_type}), "
         '"pack size did not match value size");'
     )
     lines.append("")

--- a/oresat_configs/scripts/gen_fw_files.py
+++ b/oresat_configs/scripts/gen_fw_files.py
@@ -686,8 +686,8 @@ def _make_bitfields_lines(obj: canopen.objectdictionary.Variable) -> list[str]:
     lines.append(INDENT4 + "} fields;")
     lines.append("} " + f"{bitfield_name}_t;")
     lines.append(
-        f"static_assert(sizeof({bitfield_name}_t) == sizeof({data_type}), "
-        '"pack size did not match value size");'
+        f"_Static_assert(sizeof({bitfield_name}_t) == sizeof({data_type}), "
+        '"packed size did not match value size");'
     )
     lines.append("")
 

--- a/oresat_configs/standard_objects.yaml
+++ b/oresat_configs/standard_objects.yaml
@@ -88,19 +88,19 @@
 - index: 0x1018
   name: identity
   object_type: record
-  subindexes: 
+  subindexes:
     - subindex: 0x1
       name: vendor_id
       description: manufacturer vendor id set by CiA
       data_type: uint32
       access_type: ro
-    
+
     - subindex: 0x2
       name: product_code
       description: ids a specific type of CANopen devices
       data_type: uint32
       access_type: ro
-    
+
     - subindex: 0x3
       name: revision_number
       bit_definitions:
@@ -108,7 +108,7 @@
         minor: "15-0"
       data_type: uint32
       access_type: ro
-    
+
     - subindex: 0x4
       name: serial_number
       description: unqiue device id for a product group or revision
@@ -125,41 +125,41 @@
 - index: 0x1200
   name: sdo_server_parameter
   object_type: record
-  subindexes: 
+  subindexes:
     - subindex: 0x1
       name: cob_id_client_to_server
       data_type: uint32
       access_type: rw
       default: 0x80000000
-    
+
     - subindex: 0x2
       name: cob_id_server_to_client
       data_type: uint32
       access_type: rw
       default: 0x80000000
-    
+
     - subindex: 0x3
       name: node_id_od_sdo_client
       data_type: uint32
       access_type: rw
       default: 1
-    
+
 - index: 0x1280
   name: sdo_client_parameter
   object_type: record
-  subindexes: 
+  subindexes:
     - subindex: 0x1
       name: cob_id_client_to_server
       data_type: uint32
       access_type: rw
       default: 0x80000000
-    
+
     - subindex: 0x2
       name: cob_id_server_to_client
       data_type: uint32
       access_type: rw
       default: 0x80000000
-    
+
     - subindex: 0x3
       name: node_id_od_sdo_client
       data_type: uint32
@@ -169,13 +169,13 @@
 - index: 0x1023
   name: os_command
   object_type: record
-  subindexes: 
+  subindexes:
     - subindex: 0x1
       name: command
       description: OS command
       data_type: domain
       access_type: rw
-    
+
     - subindex: 0x2
       name: status
       value_descriptions:
@@ -186,13 +186,13 @@
         executing: 0xFF
       data_type: uint32
       access_type: ro
-    
+
     - subindex: 0x3
       name: reply
       description: OS command reply
       data_type: domain
       access_type: ro
-    
+
 - index: 0x2010
   name: scet
   object_type: variable


### PR DESCRIPTION
Changes: 

- Add enums and bitfields to OD.h
- `#define OD_CNT_...` in OD.h are no longer hard-coded (this does break `oresat-firmware`, but I will have tiny fix PR for that as well)
- Fix a EMCY cob id bug when multiple cards exists (effects solar and rw)
- Remove some very old legacy code in CANopenNode file generator
- Remove whitespace in some yaml configs