### PR TITLE
Add yamllint

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -29,4 +29,3 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,6 +46,9 @@ jobs:
     - name: Test with Python's unittest
       run: python -m unittest
 
+    - name: Lint Yaml with yamllint
+      run: yamllint oresat_configs
+
     - name: Test building pypi package
       run: python -m build
 
@@ -65,6 +68,6 @@ jobs:
         oresat-configs cards > /dev/null
         oresat-configs pdo c3 --list > /dev/null
         pip uninstall -y oresat-configs
-    
+
     - name: Compile Kaitai
       run: ksc -t python oresat0_5.ksy

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,6 @@
+extends: default
+
+rules:
+  document-start: disable
+  line-length:
+    max: 100

--- a/oresat_configs/base/c3.yaml
+++ b/oresat_configs/base/c3.yaml
@@ -22,7 +22,7 @@ objects:
     data_type: uint32
     description: the reset system timeout
     access_type: const
-    default: 86400 # 24 hours
+    default: 86400  # 24 hours
     unit: s
 
   - index: 0x4002
@@ -52,7 +52,7 @@ objects:
         data_type: uint32
         description: tx enable timeout
         access_type: const
-        default: 2592000 # 30 days
+        default: 2592000  # 30 days
         unit: s
 
       - subindex: 0x3
@@ -84,7 +84,7 @@ objects:
         data_type: uint16
         description: timeout before trying to deploy the antennas
         access_type: const
-        default: 300 # 5 minutes
+        default: 300  # 5 minutes
         unit: s
 
       - subindex: 0x4
@@ -178,7 +178,7 @@ objects:
       - subindex: 0x3
         name: rssi
         data_type: int8
-        description: lband rssi of last packet received after lna, filters, and digital channel filter
+        description: lband rssi of last packet received as reported by AX5043
         access_type: ro
         unit: dB
 
@@ -197,7 +197,7 @@ objects:
   - index: 0x4007
     name: uhf
     object_type: record
-    subindexes :
+    subindexes:
       - subindex: 0x1
         name: rx_bytes
         data_type: uint32
@@ -641,23 +641,23 @@ objects:
         default: "{}"
 
 tpdos:
-  - num: 1 # time sync TPDO
+  - num: 1  # time sync TPDO
     fields:
       - [scet]
 
   - num: 2
     fields:
-    - [status]
-    - [tx_control, enable]
-    - [mode]
-    - [adcs_manager, mode]
-    - [adcs_manager, status]
+      - [status]
+      - [tx_control, enable]
+      - [mode]
+      - [adcs_manager, mode]
+      - [adcs_manager, status]
     event_timer_ms: 5000
 
   - num: 3
     fields:
-    - [edl, sequence_count]
-    - [edl, rejected_count]
+      - [edl, sequence_count]
+      - [edl, rejected_count]
     event_timer_ms: 5000
 
   - num: 4

--- a/oresat_configs/base/cfc.yaml
+++ b/oresat_configs/base/cfc.yaml
@@ -124,7 +124,7 @@ objects:
       - subindex: 0x8
         name: moving_avg_samples
         data_type: uint8
-        description: the number of reading used to calcuate the moving average to determine if saturated
+        description: the number of samples used in the moving average to determine if saturated
         access_type: rw
         default: 4
 
@@ -139,7 +139,9 @@ objects:
       - subindex: 0xa
         name: cooldown_temperature
         data_type: int8
-        description: once saturated the TEC controller cannot be enable until the camera temperature is greater this value
+        description: >
+          once saturated the TEC controller cannot be enabled until the camera temperature is
+          greater than this value
         access_type: rw
         default: 40
         unit: C

--- a/oresat_configs/base/diode_test.yaml
+++ b/oresat_configs/base/diode_test.yaml
@@ -47,13 +47,13 @@ objects:
         description: status bits
         access_type: rw
         bit_definitions:
-           DAC_EN: 0
-           GPT_EN: 1
-           ADC_EN: 2
-           MUX_EN: 3
-           MUX_A0: 4
-           MUX_A1: 5
-           MUX_A2: 6
+          DAC_EN: 0
+          GPT_EN: 1
+          ADC_EN: 2
+          MUX_EN: 3
+          MUX_A0: 4
+          MUX_A1: 5
+          MUX_A2: 6
 
       - subindex: 0x5
         name: error
@@ -109,5 +109,3 @@ tpdos:
       - [adcsample, led_swir_pd_current]
       - [adcsample, uv_pd_current]
     event_timer_ms: 10000
-
-

--- a/oresat_configs/base/dxwifi.yaml
+++ b/oresat_configs/base/dxwifi.yaml
@@ -86,7 +86,7 @@ objects:
         name: static_image
         data_type: bool
         description: transmission will send a static image rather than captured images
-        default: True
+        default: true
 
       - subindex: 0x2
         name: bit_rate
@@ -99,7 +99,7 @@ objects:
         name: as_tar
         data_type: bool
         description: transmit image as a gzipped tar file (does not apply to static image)
-        default: True
+        default: true
 
       - subindex: 0x4
         name: images_transmitted
@@ -111,7 +111,7 @@ objects:
         name: enable_pa
         data_type: bool
         description: enables the power amplifier
-        default: False
+        default: false
 
 
 tpdos:

--- a/oresat_configs/base/fw_common.yaml
+++ b/oresat_configs/base/fw_common.yaml
@@ -98,7 +98,7 @@ objects:
         scale_factor: 0.001
         unit: V
 
-      # subindex 0x9 reserved for boot_select
+        # subindex 0x9 reserved for boot_select
 
   # index 0x3004 reserved
   # index 0x3005 reserved

--- a/oresat_configs/base/gps.yaml
+++ b/oresat_configs/base/gps.yaml
@@ -57,7 +57,7 @@ objects:
         data_type: int32
         description: latitude
         access_type: ro
-        scale_factor: 0.0000001 # 1e-7
+        scale_factor: 1.0e-7
         unit: deg
         low_limit: -900000000
         high_limit: 900000000
@@ -67,7 +67,7 @@ objects:
         data_type: int32
         description: longitude
         access_type: ro
-        scale_factor: 0.0000001 # 1e-7
+        scale_factor: 1.0e-7
         unit: deg
         low_limit: -1800000000
         high_limit: 1800000000
@@ -78,7 +78,7 @@ objects:
         description: height above ellipsoid
         access_type: ro
         unit: km
-        scale_factor: 0.00001 # cm to km
+        scale_factor: 0.00001  # cm to km
 
       - subindex: 0x8
         name: mean_sea_lvl_alt
@@ -86,7 +86,7 @@ objects:
         description: mean sea level
         access_type: ro
         unit: km
-        scale_factor: 0.00001 # cm to km
+        scale_factor: 0.00001  # cm to km
 
       - subindex: 0x9
         name: gdop
@@ -129,7 +129,7 @@ objects:
         description: ecef x coordinate
         access_type: ro
         unit: km
-        scale_factor: 0.00001 # cm to km
+        scale_factor: 0.00001  # cm to km
 
       - subindex: 0xf
         name: ecef_y
@@ -137,7 +137,7 @@ objects:
         description: ecef y coordinate
         access_type: ro
         unit: km
-        scale_factor: 0.00001 # cm to km
+        scale_factor: 0.00001  # cm to km
 
       - subindex: 0x10
         name: ecef_z
@@ -145,7 +145,7 @@ objects:
         description: ecef z coordinate
         access_type: ro
         unit: km
-        scale_factor: 0.00001 # cm to km
+        scale_factor: 0.00001  # cm to km
 
       - subindex: 0x11
         name: ecef_vx
@@ -153,7 +153,7 @@ objects:
         description: ecef x velocity
         access_type: ro
         unit: km/s
-        scale_factor: 0.00001 # cm/s to km/s
+        scale_factor: 0.00001  # cm/s to km/s
 
       - subindex: 0x12
         name: ecef_vy
@@ -161,7 +161,7 @@ objects:
         description: ecef y velocity
         access_type: ro
         unit: km/s
-        scale_factor: 0.00001 # cm/s to km/s
+        scale_factor: 0.00001  # cm/s to km/s
 
       - subindex: 0x13
         name: ecef_vz
@@ -169,7 +169,7 @@ objects:
         description: ecef z velocity
         access_type: ro
         unit: km/s
-        scale_factor: 0.00001 # cm/s to km/s
+        scale_factor: 0.00001  # cm/s to km/s
 
       - subindex: 0x14
         name: time_since_midnight
@@ -193,7 +193,7 @@ objects:
 tpdos:
   - num: 3
     fields:
-      -  [skytraq, time_since_midnight]
+      - [skytraq, time_since_midnight]
 
   - num: 4
     fields:
@@ -218,7 +218,7 @@ tpdos:
       - [time_syncd]
     event_timer_ms: 1000
 
-  - num: 16 # the time sync TPDO
+  - num: 16  # the time sync TPDO
     fields:
       - [scet]
     sync: 1

--- a/oresat_configs/base/reaction_wheel.yaml
+++ b/oresat_configs/base/reaction_wheel.yaml
@@ -1,6 +1,6 @@
 objects:
   - index: 0x4000
-    name:  ctrl_stat
+    name: ctrl_stat
     description: reaction wheel controller status
     object_type: record
     subindexes:

--- a/oresat_configs/base/sw_common.yaml
+++ b/oresat_configs/base/sw_common.yaml
@@ -296,4 +296,4 @@ tpdos:
 rpdos:
   - num: 1
     card: c3
-    tpdo_num: 1 # the time sync TPDO
+    tpdo_num: 1  # the time sync TPDO

--- a/oresat_configs/oresat0/beacon.yaml
+++ b/oresat_configs/oresat0/beacon.yaml
@@ -4,8 +4,8 @@ ax25:
   dest_ssid: 0
   src_callsign: KJ7SAT
   src_ssid: 0
-  control: 0x3 # ui-frame
-  pid: 0xf0 # no L3 protocol
+  control: 0x3  # ui-frame
+  pid: 0xf0  # no L3 protocol
   command: false
   response: false
 fields:

--- a/oresat_configs/oresat0_5/beacon.yaml
+++ b/oresat_configs/oresat0_5/beacon.yaml
@@ -1,11 +1,11 @@
 revision: 0
 ax25:
   dest_callsign: SPACE
-  dest_ssid: 0 # primary station
+  dest_ssid: 0  # primary station
   src_callsign: KJ7SAT
-  src_ssid: 11 # balloons, aircraft, spacecraft, etc
-  control: 0x3 # ui-frame
-  pid: 0xf0 # no L3 protocol
+  src_ssid: 11  # balloons, aircraft, spacecraft, etc
+  control: 0x3  # ui-frame
+  pid: 0xf0  # no L3 protocol
   command: false
   response: true
 fields:

--- a/oresat_configs/oresat1/beacon.yaml
+++ b/oresat_configs/oresat1/beacon.yaml
@@ -1,11 +1,11 @@
 revision: 0
 ax25:
   dest_callsign: SPACE
-  dest_ssid: 0 # primary station
+  dest_ssid: 0  # primary station
   src_callsign: KJ7SAT
-  src_ssid: 11 # balloons, aircraft, spacecraft, etc
-  control: 0x3 # ui-frame
-  pid: 0xf0 # no L3 protocol
+  src_ssid: 11  # balloons, aircraft, spacecraft, etc
+  control: 0x3  # ui-frame
+  pid: 0xf0  # no L3 protocol
   command: false
   response: true
 fields:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ sphinx-rtd-theme
 tabulate
 types-tabulate
 wheel
+yamllint


### PR DESCRIPTION
yamllint is a linter for yaml (who would have thought) which will help with catching indentation, excess spaces, and things like that. This specific pass caught
- A couple of mis-indented lists
- Two spaces before inline comments, like how black does
- Some lines greater than 100 characters
- Excess spaces around some syntax

I disabled warning on missing document start because they're optional and we're fairly unambiguous about what we're doing. I also changed two floats to scientific notation, but pyyamls parser for that is a bit annoying. It will interpret them as a float and not a string only under the conditions where it has a decimal point and a sign on the exponent.