### PR TITLE
Fix array and corrected rw configs

### DIFF
--- a/oresat_configs/base/reaction_wheel.yaml
+++ b/oresat_configs/base/reaction_wheel.yaml
@@ -1,6 +1,6 @@
 objects:
   - index: 0x4000
-    name:  ctrl_stat
+    name: ctrl_stat
     description: reaction wheel controller status
     object_type: record
     subindexes:
@@ -9,6 +9,24 @@ objects:
         data_type: uint8
         description: controller state
         access_type: ro
+        value_descriptions:
+          none: 0
+          idle: 1
+          system_error: 2
+          controller_error: 3
+          torque_control: 4
+          vel_control: 5
+          pos_control: 6
+          motor_resistance_cal: 7
+          motor_inductance_cal: 8
+          encoder_dir_cal: 9
+          encoder_offset_cal: 10
+          encoder_test: 11
+          open_loop_control: 12
+          clear_errors: 13
+          encoder_validation: 14
+          shitty_offset_cal: 15
+          vel_ramp_control: 16
 
       - subindex: 0x2
         name: procedure_result
@@ -21,6 +39,29 @@ objects:
         data_type: uint32
         description: system error bitmask
         access_type: ro
+        bit_definitions:
+          inverter_calibration_invalid: 0
+          phase_currents_invalid: 1
+          phase_currents_measurement_missing: 2
+          pwm_timing_invalid: 3
+          pwm_timing_update_missing: 4
+          vbus_overvoltage: 5
+          vbus_undervoltage: 6
+          ibus_overcurrent: 7
+          motor_overcurrent: 8
+          motor_phase_leakage: 9
+          motor_resistance_out_of_range: 10
+          motor_inductance_out_of_range: 11
+          encoder_reading_missing: 12
+          encoder_estimate_missing: 13
+          encoder_reading_invalid: 14
+          encoder_failure: 15
+          phase_current_usage_missing: 16
+          pwm_timing_usage_missing: 17
+          phase_current_leakage: 18
+          encoder_reading_usage_missing: 19
+          motor_unbalanced_phases: 20
+          modulation: 21
 
   - index: 0x4001
     name: motor

--- a/oresat_configs/base/reaction_wheel.yaml
+++ b/oresat_configs/base/reaction_wheel.yaml
@@ -104,31 +104,15 @@ objects:
   - index: 0x4003
     name: temperature
     description: reaction wheel controller temperatures
-    object_type: record
-    subindexes:
-      - subindex: 0x1
-        name: sensor_1
-        data_type: int16
-        description: temperature sensor 1 temp
-        access_type: ro
-        unit: C
-        scale_factor: 0.01
-
-      - subindex: 0x2
-        name: sensor_2
-        data_type: int16
-        description: temperature sensor 2 temp
-        access_type: ro
-        unit: C
-        scale_factor: 0.01
-
-      - subindex: 0x3
-        name: sensor_3
-        data_type: int16
-        description: temperature sensor 3 temp
-        access_type: ro
-        unit: C
-        scale_factor: 0.01
+    object_type: array
+    generate_subindexes:
+      subindexes: fixed_length
+      length: 3
+      name: sensor
+      data_type: int16
+      access_type: ro
+      unit: C
+      scale_factor: 0.01
 
   - index: 0x4004
     name: requested
@@ -192,23 +176,23 @@ tpdos:
       - [ctrl_stat, current_state]
       - [ctrl_stat, procedure_result]
       - [ctrl_stat, errors]
-    event_timer_ms: 100
+    event_timer_ms: 5000
 
   - num: 2
     fields:
       - [motor, velocity]
       - [motor, current]
-    event_timer_ms: 100
+    event_timer_ms: 5000
 
   - num: 3
     fields:
       - [bus, voltage]
       - [bus, current]
-    event_timer_ms: 100
+    event_timer_ms: 5000
 
   - num: 4
     fields:
       - [temperature, sensor_1]
       - [temperature, sensor_2]
       - [temperature, sensor_3]
-    event_timer_ms: 100
+    event_timer_ms: 5000

--- a/oresat_configs/card_config.py
+++ b/oresat_configs/card_config.py
@@ -55,20 +55,55 @@ class GenerateSubindex(ConfigObject):
 
     .. code-block:: yaml
 
-        subindexes: node_ids
-        names: node_ids
-        data_type: uint8
-        access_type: ro
-        value_descriptions:
-          0: "OFF"
-          1: "BOOT"
-          2: "ON"
-          3: "ERROR"
-          4: "NOT_FOUND"
-          0xFF: "DEAD"
+      - index: 0x4000
+        name: my_array
+        object_type: array
+        generate_subindexes:
+            subindexes: fixed_length
+            name: item
+            length: 10
+            data_type: uint16
+            access_type: ro
+            unit: C
+            scale_factor: 0.001
+
+    will generate the equivalent of
+
+    .. code-block:: yaml
+
+      - index: 0x4000
+        name: my_array
+        object_type: array
+        subindexes:
+        generate_subindexes:
+        - subindex: 1
+          name: item_1
+          data_type: uint16
+          access_type: ro
+          unit: C
+          scale_factor: 0.001
+        - subindex: 2
+          name: item_2
+          data_type: uint16
+          access_type: ro
+          unit: C
+          scale_factor: 0.001
+        ...
+        - subindex: 9
+          name: item_9
+          data_type: uint16
+          access_type: ro
+          unit: C
+          scale_factor: 0.001
+        - subindex: 10
+          name: item_10
+          data_type: uint16
+          access_type: ro
+          unit: C
+          scale_factor: 0.001
     """
 
-    names: str = ""
+    name: str = ""
     """Names of objects to generate."""
     subindexes: Union[str, int] = 0
     """Subindexes of objects to generate."""

--- a/oresat_configs/standard_objects.yaml
+++ b/oresat_configs/standard_objects.yaml
@@ -26,6 +26,7 @@
   object_type: array
   description: emcy history for device
   generate_subindexes:
+    name: error
     subindexes: fixed_length
     length: 8  # can be up to 127
     data_type: uint32


### PR DESCRIPTION
This is a collection of things I found while working on the rw firmware

- Arrays were completely broken other than generated node id ones for the c3. I fixed them to work similar to records and also support fix length generation
- Added the rw enums and bitfields
- Set the rw tpdo event timer to values that were changed by fw