### PR TITLE
Additional standard object specifications

### DIFF
--- a/oresat_configs/_yaml_to_od.py
+++ b/oresat_configs/_yaml_to_od.py
@@ -174,8 +174,7 @@ def _make_arr(obj: IndexObject, node_ids: dict[str, int]) -> Array:
             var = canopen.objectdictionary.Variable(name, index, subindex)
             var.access_type = gen_sub.access_type
             var.data_type = STR_2_OD_DATA_TYPE[gen_sub.data_type]
-            for name, bits in gen_sub.bit_definitions.items():
-                var.add_bit_definition(name, bits)
+            var.bit_definitions = _parse_bit_definitions(gen_sub)
             for name, value in gen_sub.value_descriptions.items():
                 var.add_value_description(value, name)
             var.unit = gen_sub.unit

--- a/oresat_configs/standard_objects.yaml
+++ b/oresat_configs/standard_objects.yaml
@@ -28,8 +28,12 @@
   generate_subindexes:
     name: error
     subindexes: fixed_length
-    length: 8  # can be up to 127
+    length: 8  # can be bewteen 1 and 254
     data_type: uint32
+    access_type: ro
+    bit_definitions:
+      additional_info: "32-16"
+      error_code: "15-0"
 
 - index: 0x1005
   name: cob_id_sync
@@ -67,6 +71,8 @@
   description: inhibit time (in 100 us) for emcy messages
   data_type: uint16
   access_type: rw
+  unit: s
+  scale_factor: 0.0001
 
 - index: 0x1016
   name: consumer_heartbeat_time
@@ -76,7 +82,10 @@
     subindexes: node_ids
     name: node_ids
     data_type: uint32
+    access_type: rw
     default: 1000
+    unit: s
+    scale_factor: 0.001
 
 - index: 0x1017
   name: producer_heartbeat_time
@@ -85,6 +94,8 @@
   data_type: uint16
   access_type: rw
   default: 1000
+  unit: s
+  scale_factor: 0.001
 
 - index: 0x1018
   name: identity
@@ -122,6 +133,7 @@
   description: highest supported value of the synchronous counter
   data_type: uint8
   access_type: rw
+  high_limit: 240
 
 - index: 0x1200
   name: sdo_server_parameter
@@ -130,20 +142,32 @@
     - subindex: 0x1
       name: cob_id_client_to_server
       data_type: uint32
-      access_type: rw
+      access_type: ro
       default: 0x80000000
+      bit_definitions:
+        not_valid: 31
+        dyn: 30
+        frame: 29
+        can_id: "10-0"
 
     - subindex: 0x2
       name: cob_id_server_to_client
       data_type: uint32
-      access_type: rw
+      access_type: ro
       default: 0x80000000
+      bit_definitions:
+        not_valid: 31
+        dyn: 30
+        frame: 29
+        can_id: "10-0"
 
     - subindex: 0x3
       name: node_id_od_sdo_client
-      data_type: uint32
-      access_type: rw
-      default: 1
+      data_type: uint8
+      access_type: ro
+      low_limit: 0x1
+      high_limit: 0x7F
+      default: 0x1
 
 - index: 0x1280
   name: sdo_client_parameter
@@ -154,12 +178,22 @@
       data_type: uint32
       access_type: rw
       default: 0x80000000
+      bit_definitions:
+        not_valid: 31
+        dyn: 30
+        frame: 29
+        can_id: "10-0"
 
     - subindex: 0x2
       name: cob_id_server_to_client
       data_type: uint32
       access_type: rw
       default: 0x80000000
+      bit_definitions:
+        not_valid: 31
+        dyn: 30
+        frame: 29
+        can_id: "10-0"
 
     - subindex: 0x3
       name: node_id_of_sdo_server


### PR DESCRIPTION
I went through CiA301 and compared the values there to what we've implemented. It's mostly correct, for the most part this just adds annotations for the data type (bit defs, units, limits) but there were two fixes of note:
- 0x1200-0x3 unit32 -> uint8. Same as 89a208 did for 0x1280.
- 0x1200 and 0x1280 are marked as RO in Table 74. The other instances of these records are RW (i.e. 0x1201 - 0x127F, 0x1281 - 0x12FF) but the first instances are RO.