### PR TITLE
Refactor `attr_lines()`

### DIFF
--- a/oresat_configs/card_info.py
+++ b/oresat_configs/card_info.py
@@ -9,7 +9,7 @@ from typing import Optional
 from . import base
 
 
-@dataclass(frozen=True)
+@dataclass
 class Card:
     """Card info."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ path = "*/__init__.py"
 ignore = "W0611,R0903"
 
 [[tool.mypy.overrides]]
-module = "canopen,canopen.objectdictionary"
+module = "canopen,canopen.objectdictionary,canopen.objectdictionary.datatypes"
 ignore_missing_imports = true
 
 [tool.isort]


### PR DESCRIPTION
`attr_lines()` was generating initializers for each of the three OD types in slightly different ways. This pulls that block out into its own function so that fixes always happen to all three types, simplifies the generating a bit, and fixes a few edge cases:
- Removed whitespace at the end of VISIBLE_STRING
- Use '\0' instead of 0 for null in VISIBLE_STRING
- VISIBLE_STRING would generate strings ("") instead of chars ('') as
  the array members for ODVariable and ODArray
- _SKIP_INDEXES are always skipped, previously ODRecords were not.

Checking over our current generated configs the only difference in generated output is using '\0' instead of 0 for VISIBLE_STRINGs and removing the single space at the end of those lines.

This has also been extended to `_canopennode_h_lines()` and `obj_lines()` with no change of generated output, although the calculation of the length of OCTET_STRING was fixed in cases where we didn't use it.