### PR TITLE
Update TPDO/OD configs for the star tracker

### DIFF
--- a/oresat_configs/_yaml_to_od.py
+++ b/oresat_configs/_yaml_to_od.py
@@ -40,6 +40,7 @@ def overlay_configs(card_config: CardConfig, overlay_config: CardConfig) -> None
                 obj2.access_type = obj.access_type
                 obj2.high_limit = obj.high_limit
                 obj2.low_limit = obj.low_limit
+                obj2.default = obj.default
             else:
                 for sub_obj in obj.subindexes:
                     sub_overlayed = False
@@ -50,6 +51,7 @@ def overlay_configs(card_config: CardConfig, overlay_config: CardConfig) -> None
                             sub_obj2.access_type = sub_obj.access_type
                             sub_obj2.high_limit = sub_obj.high_limit
                             sub_obj2.low_limit = sub_obj.low_limit
+                            sub_obj2.default = sub_obj.default
                             overlayed = True
                             sub_overlayed = True
                             break  # obj was found, search for next one
@@ -64,7 +66,7 @@ def overlay_configs(card_config: CardConfig, overlay_config: CardConfig) -> None
     for overlay_tpdo in overlay_config.tpdos:
         overlayed = False
         for card_tpdo in card_config.tpdos:
-            if card_tpdo.num == card_tpdo.num:
+            if card_tpdo.num == overlay_tpdo.num:
                 card_tpdo.fields = overlay_tpdo.fields
                 card_tpdo.event_timer_ms = overlay_tpdo.event_timer_ms
                 card_tpdo.inhibit_time_ms = overlay_tpdo.inhibit_time_ms
@@ -78,7 +80,7 @@ def overlay_configs(card_config: CardConfig, overlay_config: CardConfig) -> None
     for overlay_rpdo in overlay_config.rpdos:
         overlayed = False
         for card_rpdo in card_config.rpdos:
-            if card_rpdo.num == card_rpdo.num:
+            if card_rpdo.num == overlay_rpdo.num:
                 card_rpdo.card = overlay_rpdo.card
                 card_rpdo.tpdo_num = overlay_rpdo.tpdo_num
                 overlayed = True

--- a/oresat_configs/base/star_tracker.yaml
+++ b/oresat_configs/base/star_tracker.yaml
@@ -71,25 +71,22 @@ objects:
     description: last solve calculations
     subindexes:
       - subindex: 0x1
-        name: right_ascension
-        data_type: int16
-        description: the right ascension of the satellite
+        name: attitude_i
+        data_type: float32
+        description: the i component of the estimated attitude quaternion
         access_type: ro
-        unit: deg
 
       - subindex: 0x2
-        name: declination
-        data_type: int16
-        description: the delination of the satellite
+        name: attitude_j
+        data_type: float32
+        description: the j component of the estimated attitude quaternion
         access_type: ro
-        unit: deg
 
       - subindex: 0x3
-        name: roll
-        data_type: int16
-        description: the roll of the satellite
+        name: attitude_k
+        data_type: float32
+        description: the k component of the estimage attitude quaternion
         access_type: ro
-        unit: deg
 
       - subindex: 0x4
         name: time_since_midnight
@@ -97,6 +94,18 @@ objects:
         description: time since midnight when the image was captured
         access_type: ro
         unit: ms
+
+      - subindex: 0x5
+        name: attitude_real
+        data_type: float32
+        description: real (scalar) component of the estimated attitude quaternion
+        access_type: ro
+
+      - subindex: 0x6
+        name: attitude_known
+        data_type: bool
+        description: flag indicating whether a valid attitude is available
+        access_type: ro
 
   - index: 0x4003
     name: capture_filter
@@ -140,10 +149,15 @@ tpdos:
   - num: 3
     fields:
       - [status]
-      - [orientation, right_ascension]
-      - [orientation, declination]
-      - [orientation, roll]
+      - [orientation, attitude_known]
+      - [orientation, time_since_midnight]
 
   - num: 4
     fields:
-      - [orientation, time_since_midnight]
+      - [orientation, attitude_real]
+      - [orientation, attitude_i]
+
+  - num: 5
+    fields:
+      - [orientation, attitude_j]
+      - [orientation, attitude_k]

--- a/oresat_configs/base/star_tracker.yaml
+++ b/oresat_configs/base/star_tracker.yaml
@@ -71,22 +71,25 @@ objects:
     description: last solve calculations
     subindexes:
       - subindex: 0x1
-        name: attitude_i
-        data_type: float32
-        description: the i component of the estimated attitude quaternion
+        name: right_ascension
+        data_type: int16
+        description: the right ascension of the satellite
         access_type: ro
+        unit: deg
 
       - subindex: 0x2
-        name: attitude_j
-        data_type: float32
-        description: the j component of the estimated attitude quaternion
+        name: declination
+        data_type: int16
+        description: the delination of the satellite
         access_type: ro
+        unit: deg
 
       - subindex: 0x3
-        name: attitude_k
-        data_type: float32
-        description: the k component of the estimage attitude quaternion
+        name: roll
+        data_type: int16
+        description: the roll of the satellite
         access_type: ro
+        unit: deg
 
       - subindex: 0x4
         name: time_since_midnight
@@ -94,18 +97,6 @@ objects:
         description: time since midnight when the image was captured
         access_type: ro
         unit: ms
-
-      - subindex: 0x5
-        name: attitude_real
-        data_type: float32
-        description: real (scalar) component of the estimated attitude quaternion
-        access_type: ro
-
-      - subindex: 0x6
-        name: attitude_known
-        data_type: bool
-        description: flag indicating whether a valid attitude is available
-        access_type: ro
 
   - index: 0x4003
     name: capture_filter
@@ -149,15 +140,10 @@ tpdos:
   - num: 3
     fields:
       - [status]
-      - [orientation, attitude_known]
-      - [orientation, time_since_midnight]
+      - [orientation, right_ascension]
+      - [orientation, declination]
+      - [orientation, roll]
 
   - num: 4
     fields:
-      - [orientation, attitude_real]
-      - [orientation, attitude_i]
-
-  - num: 5
-    fields:
-      - [orientation, attitude_j]
-      - [orientation, attitude_k]
+      - [orientation, time_since_midnight]

--- a/oresat_configs/oresat1/star_tracker_overlay.yaml
+++ b/oresat_configs/oresat1/star_tracker_overlay.yaml
@@ -1,0 +1,70 @@
+objects:
+  - index: 0x4001
+    name: capture
+    object_type: record
+    subindexes:
+      - subindex: 0x2
+        name: delay
+        data_type: uint32
+        description: delay between captures
+        default: 100
+        unit: ms
+
+  - index: 0x4002
+    name: orientation
+    object_type: record
+    description: last solve calculations
+    subindexes:
+      - subindex: 0x1
+        name: attitude_i
+        data_type: float32
+        description: the i component of the estimated attitude quaternion
+        access_type: ro
+
+      - subindex: 0x2
+        name: attitude_j
+        data_type: float32
+        description: the j component of the estimated attitude quaternion
+        access_type: ro
+
+      - subindex: 0x3
+        name: attitude_k
+        data_type: float32
+        description: the k component of the estimage attitude quaternion
+        access_type: ro
+
+      - subindex: 0x4
+        name: time_since_midnight
+        data_type: uint32
+        description: time since midnight when the image was captured
+        access_type: ro
+        unit: ms
+
+      - subindex: 0x5
+        name: attitude_real
+        data_type: float32
+        description: real (scalar) component of the estimated attitude quaternion
+        access_type: ro
+
+      - subindex: 0x6
+        name: attitude_known
+        data_type: bool
+        description: flag indicating whether a valid attitude is available
+        access_type: ro
+
+tpdos:
+  - num: 3
+    fields:
+      - [status]
+      - [orientation, attitude_known]
+      - [orientation, time_since_midnight]
+
+  - num: 4
+    fields:
+      - [orientation, attitude_real]
+      - [orientation, attitude_i]
+
+  - num: 5
+    fields:
+      - [orientation, attitude_j]
+      - [orientation, attitude_k]

--- a/tests/test_od_generation.py
+++ b/tests/test_od_generation.py
@@ -1,0 +1,28 @@
+'''Test that the yaml to od conversion works as expected'''
+
+from importlib import resources
+
+from oresat_configs import OreSatConfig
+from oresat_configs.card_config import CardConfig
+
+
+class TestOdGeneration:
+    def test_tpdo_overlay(self, config: OreSatConfig) -> None:
+        # For every overlay tpdo, check that it ends up exactly in the final config
+        for name, overlay_path in config.mission.overlays.items():
+            with resources.as_file(overlay_path) as path:
+                overlay = CardConfig.from_yaml(path)
+            for cardname, cfg in config.configs.items():
+                if cardname.startswith(name):
+                    for tpdo in overlay.tpdos:
+                        assert tpdo in cfg.tpdos
+
+    def test_rpdo_overlay(self, config: OreSatConfig) -> None:
+        # For every overlay rpdo, check that it ends up exactly in the final config
+        for name, overlay_path in config.mission.overlays.items():
+            with resources.as_file(overlay_path) as path:
+                overlay = CardConfig.from_yaml(path)
+            for cardname, cfg in config.configs.items():
+                if cardname.startswith(name):
+                    for tpdo in overlay.rpdos:
+                        assert tpdo in cfg.rpdos


### PR DESCRIPTION
Addresses new ADCS requirements to supply the attitude estimate as a quaternion from the star tracker. This should close #55.