### PR TITLE
Add 0x6 check_for_updates to updater index.

### DIFF
--- a/oresat_configs/base/sw_common.yaml
+++ b/oresat_configs/base/sw_common.yaml
@@ -231,6 +231,12 @@ objects:
         description: add a updater system status file to the fread cache
         access_type: wo
 
+      - subindex: 0x6
+        name: check_for_updates
+        data_type: bool
+        description: force the updater service to check for and distribute update files
+        access_type: wo
+
   - index: 0x3007
     name: logs
     object_type: record


### PR DESCRIPTION
Creates the `check_for_updates` entry in sw common, which will force the updater service to look for new update files. This will also cause the c3 to transfer update files for non-c3 cards to the designated card.