### PR TITLE
Update gen_eds to support EDSEditor/CANopenNode 1.3/2.0

### DIFF
--- a/oresat_configs/scripts/gen_eds.py
+++ b/oresat_configs/scripts/gen_eds.py
@@ -3,8 +3,11 @@ from pathlib import Path
 from typing import Any
 
 from canopen import ObjectDictionary, export_od
+from canopen.objectdictionary import ODArray, ODVariable
+from canopen.objectdictionary.datatypes import OCTET_STRING, UNSIGNED8, UNSIGNED32
 
 from .. import Mission, OreSatConfig
+from ..card_config import Rpdo
 
 
 def build_arguments(subparsers: Any) -> None:
@@ -45,6 +48,9 @@ def gen_eds(args: Namespace) -> None:
     config = OreSatConfig(args.oresat)
 
     def write_eds(od: ObjectDictionary) -> None:
+        if od.device_information.product_name is None:
+            raise SystemExit("OD incomplete (missing product name)")
+        fixup_od(od)
         file = od.device_information.product_name + ".eds"
         file = file.lower().replace(" ", "_")
         path = args.dir_path / file
@@ -56,3 +62,130 @@ def gen_eds(args: Namespace) -> None:
             write_eds(od)
     else:
         write_eds(config.od_db[config.name_from_alias(args.card)])
+
+
+def fixup_od(od: ObjectDictionary) -> None:
+    '''Fixes to our OD to support EDSEditor/CANopenNode 1.3/2.0.'''
+    d = od.device_information
+    if d.nr_of_RXPDO is None:
+        raise SystemExit("OD incomplete (missing RXPDO count)")
+
+    # For the canopen-python eds generator it expets baud instead of kilobaud
+    d.allowed_baudrates = {1000 * baud for baud in d.allowed_baudrates}
+    # CANopenNode needs at least one RPDO to compile so we point at a
+    # random object and then disable the PDO.
+    if d.nr_of_RXPDO < 1:
+        rpdo = Rpdo(num=1, card='', tpdo_num=1, fields=[['scet']])
+        mp = rpdo.to_mapping_parameter(od)
+        mp[0].value = 0
+        od.add_object(mp)
+        od.add_object(rpdo.to_communication_parameter(0))
+        # upstream type annotation is obviuosly incorrect - marked as optional[bool] for a number?
+        d.nr_of_RXPDO = 1  # type: ignore[assignment]
+
+    # EDSEditor expects a bunch of objects to be named in a specific way
+    pdo_mappings = []
+    for index, obj in od.items():
+        if index == 0x1001:
+            obj.name = "Error register"
+        elif index == 0x1003:
+            obj.name = "Pre-defined error field"
+        elif index == 0x1005:
+            obj.name = "COB_ID_SYNCMessage"
+        elif index == 0x1006:
+            obj.name = "Communication Cycle Period"
+        elif index == 0x1015:
+            obj.name = "Inhibit time EMCY"
+        elif index == 0x1017:
+            obj.name = "Producer heartbeat time"
+        elif index == 0x1018:
+            for subindex, subobj in obj.items():
+                if subindex == 0x01:
+                    subobj.name = "vendorID"
+                elif subindex == 0x02:
+                    subobj.name = "productCode"
+                elif subindex == 0x03:
+                    subobj.name = "revisionNumber"
+                elif subindex == 0x04:
+                    subobj.name = "serialNumber"
+        elif 0x1200 <= index < 0x1300:
+            obj.name = "SDO server parameter"
+            for subindex, subobj in obj.items():
+                if subindex == 0x01:
+                    subobj.name = "COB_IDClientToServer"
+                elif subindex == 0x02:
+                    subobj.name = "COB_IDServerToClient"
+        elif 0x1400 <= index < 0x1600:
+            obj.name = "RPDOCommunicationParameter"
+        elif 0x1600 <= index < 0x1800:
+            obj.name = "RPDOMappingParameter"
+            pdo_mappings.append(obj)
+        elif 0x1800 <= index < 0x1A00:
+            obj.name = "TPDOCommunicationParameter"
+        elif 0x1A00 <= index < 0x1C00:
+            obj.name = "TPDOMappingParameter"
+            pdo_mappings.append(obj)
+
+    # CANopenNode 1.3/2.0 expects all the Mapping Parameters to be length 8 for each PDO
+    for obj in pdo_mappings:
+        for subindex in range(1, 8 + 1):
+            if subindex not in obj:
+                map_obj = ODVariable(f"mapping_object_{subindex}", obj.index, subindex)
+                map_obj.data_type = UNSIGNED32
+                map_obj.value = 0
+                map_obj.default = 0
+                obj.add_member(map_obj)
+
+    # There's a bunch of manditory "optional" objects that CANOpenNode 1.3/2.0 expects, here we
+    # define them all in their disabled setting.
+    sync_win = ODVariable("Synchronous window length", 0x1007)
+    sync_win.data_type = UNSIGNED32
+    sync_win.default = 0
+    sync_win.value = 0
+    od.add_object(sync_win)
+
+    sync_overflow = ODVariable("Synchronous counter overflow value", 0x1019)
+    sync_overflow.data_type = UNSIGNED8
+    sync_overflow.default = 0
+    sync_overflow.value = 0
+    od.add_object(sync_overflow)
+
+    error_behavior = ODArray("Error behavior", 0x1029)
+    hsubs = ODVariable("highest_index_supported", 0x1029, 0x00)
+    hsubs.data_type = UNSIGNED8
+    hsubs.default = 1
+    hsubs.value = 1
+    hsubs.access_type = "const"
+    comm_error = ODVariable("Communication error", 0x1029, 0x01)
+    comm_error.data_type = UNSIGNED8
+    comm_error.default = 0
+    comm_error.value = 0
+    error_behavior.add_member(hsubs)
+    error_behavior.add_member(comm_error)
+    od.add_object(error_behavior)
+
+    nmt_startup = ODVariable("NMTStartup", 0x1F80)
+    nmt_startup.data_type = UNSIGNED32
+    nmt_startup.default = 0
+    nmt_startup.value = 0
+    od.add_object(nmt_startup)
+
+    hbconsumer = ODArray("Consumer heartbeat time", 0x1016)
+    hsubs = ODVariable("highest_index_supported", 0x1016, 0x00)
+    hsubs.data_type = UNSIGNED8
+    hsubs.default = 1
+    hsubs.value = 1
+    hbc = ODVariable("Consumer heartbeat time", 0x1016, 0x01)
+    hbc.data_type = UNSIGNED32
+    hbc.default = 0
+    hbc.value = 0
+    hbconsumer.add_member(hsubs)
+    hbconsumer.add_member(hbc)
+    od.add_object(hbconsumer)
+
+    errorstatus = ODVariable("Error Status Bits", 0x2100)
+    errorstatus.data_type = OCTET_STRING
+    # Upstream type annotations are obviously wrong
+    errorstatus.default = bytes(10)  # type: ignore[assignment]
+    errorstatus.value = bytes(10)  # type: ignore[assignment]
+    od.add_object(errorstatus)


### PR DESCRIPTION
The earlier CANopenNodes are much more picky about the configs they ingest, we have to apply a bunch of fixups to the object dictionary before emitting a compatible EDS.